### PR TITLE
Fix midnight painting bug

### DIFF
--- a/app/_lib/availability/utils.tsx
+++ b/app/_lib/availability/utils.tsx
@@ -135,7 +135,10 @@ export function generateDragSlots(
   while (current <= end) {
     slots.add(current.toISOString());
     current.setMinutes(current.getMinutes() + 15);
-    if (current.getHours() < start.getHours()) {
+    if (
+      current.getHours() * 60 + current.getMinutes() <
+      start.getHours() * 60 + start.getMinutes()
+    ) {
       // Avoid wrapping to the next day around midnight
       current.setHours(start.getHours(), start.getMinutes());
     }


### PR DESCRIPTION
This PR fixes a small bug on the painting page.

When the user would paint up to midnight, the generateDragSlots function would fill every slot in the day, resulting in some extra slots being toggled unintentionally.

This is fixed by just checking if the current time is before the start time, then clamping the value to the correct time range.