### PR TITLE
Line ending conversion hotfix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Always normalize to LF in Git
-* text eol=lf
+text=auto eol=lf


### PR DESCRIPTION
This PR fixes the issue with line endings being converted on every type of file, including binary. The `.gitattributes` file will now only convert line endings on text files.

This is quite important because if you ever switch to main you're stuck there unless you delete the `favicon.ico` file and perform an odd procedure. This ensures that other developers don't unknowingly find themselves in that situation.