### PR TITLE
Toast persistence bug fix

### DIFF
--- a/src/features/toast/base.tsx
+++ b/src/features/toast/base.tsx
@@ -42,6 +42,18 @@ export default function BaseToast({
         <button
           type="button"
           aria-label="Close"
+          onClick={() => {
+            if (
+              document.activeElement &&
+              document.activeElement instanceof HTMLElement
+            ) {
+              // After clicking this button, the focus would be on the toasts.
+              // If there is more than 1 toast, the focus causes the timers for all the
+              // toasts to be paused until the user clicked on something else.
+              // This just removes that focus.
+              document.activeElement.blur();
+            }
+          }}
           className={cn(
             "col-start-3 row-span-2 flex h-6 w-6 items-center justify-center rounded-full",
             "opacity-0 transition-all",


### PR DESCRIPTION
This PR fixes a bug where if:
- the user clicks on a toast to dismiss it
- and there are multiple toasts open at once

then the remaining toasts would stay indefinitely until clicking somewhere else.

This is caused by the Radix UI timeout pause. If the user is either hovering over a toast or focused on it, the timeout would be paused to allow the user to read the toast for as long as they need. In this case, the focus was kept on the toasts after clicking the close button, resulting in the rest of the toasts persisting for longer than they should.

The fix is just to remove the focus from the toasts after clicking on the close button.