### PR TITLE
fixed time zone picker padding

### DIFF
--- a/src/app/(event)/[event-code]/page-client.tsx
+++ b/src/app/(event)/[event-code]/page-client.tsx
@@ -113,7 +113,7 @@ export default function ClientPage({
             <EventInfo eventRange={eventRange} />
           </div>
 
-          <div className="bg-panel hidden rounded-3xl p-4 text-sm md:block">
+          <div className="bg-panel hidden rounded-3xl p-6 text-sm md:block">
             Displaying event in
             <span className="text-accent ml-1 font-bold">
               <TimeZoneSelector


### PR DESCRIPTION
I fixed the padding for timezone picker panel on the results page as it was not consistent with the padding for the other panels on  the page.