### PR TITLE
Timezone panel padding

### DIFF
--- a/src/app/(event)/[event-code]/painting/page-client.tsx
+++ b/src/app/(event)/[event-code]/painting/page-client.tsx
@@ -133,7 +133,7 @@ export default function ClientPage({
       {/* Main Content */}
       <div className="mb-12 flex h-fit flex-col gap-4 md:mb-0 md:flex-row">
         {/* Left Panel */}
-        <div className="md:top-25 h-fit w-full shrink-0 space-y-6 overflow-y-auto md:sticky md:w-80">
+        <div className="md:top-25 h-fit w-full shrink-0 space-y-4 overflow-y-auto md:sticky md:w-80">
           <div className="w-fit">
             <p
               className={`text-error text-right text-xs ${errors.displayName ? "visible" : "invisible"}`}


### PR DESCRIPTION
I fixed the padding for the timezone picker panel on the results page and painting page as it was not consistent with the padding for the other panels on the pages.