### PR TITLE
password checking fixed

### DIFF
--- a/src/components/text-input-field.tsx
+++ b/src/components/text-input-field.tsx
@@ -16,14 +16,26 @@ type TextInputFieldProps = {
   label: string;
   value: string;
   onChange: (value: string) => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
   outlined?: boolean;
   error?: string;
   classname?: string;
 };
 
 export default function TextInputField(props: TextInputFieldProps) {
-  const { id, type, label, value, onChange, error, outlined, classname } =
-    props;
+  const {
+    id,
+    type,
+    label,
+    value,
+    onChange,
+    onFocus,
+    onBlur,
+    error,
+    outlined,
+    classname,
+  } = props;
   const [showPassword, setShowPassword] = useState(false);
 
   // determine input type
@@ -38,6 +50,8 @@ export default function TextInputField(props: TextInputFieldProps) {
         id={id}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onFocus={onFocus}
+        onBlur={onBlur}
         placeholder=" " // triggers placeholder-shown state for floating label
         className={cn(
           "peer w-full bg-transparent py-2",

--- a/src/features/auth/components/password-criteria.tsx
+++ b/src/features/auth/components/password-criteria.tsx
@@ -7,21 +7,32 @@ type PasswordCriteriaProps = {
 };
 
 export default function PasswordCriteria(props: PasswordCriteriaProps) {
+  const allCriteriaMet = Object.values(props.criteria).every((value) => value);
+
   return (
     <div className="w-full text-sm">
-      <b>Your password must:</b>
-      {Object.entries(props.criteria).map(([key, value], index) => (
-        <div
-          key={index}
-          className={cn(
-            "flex items-center gap-1",
-            value ? "line-through opacity-50" : "",
-          )}
-        >
-          {value ? <CheckIcon /> : <Cross2Icon />}
-          {key}
+      {allCriteriaMet ? (
+        <div className="flex items-center gap-1">
+          <CheckIcon />
+          <b>Password is strong!</b>
         </div>
-      ))}
+      ) : (
+        <>
+          <b>Your password must:</b>
+          {Object.entries(props.criteria).map(([key, value], index) => (
+            <div
+              key={index}
+              className={cn(
+                "flex items-center gap-1",
+                value ? "line-through opacity-50" : "",
+              )}
+            >
+              {value ? <CheckIcon /> : <Cross2Icon />}
+              {key}
+            </div>
+          ))}
+        </>
+      )}
     </div>
   );
 }

--- a/src/features/auth/components/password-validation.ts
+++ b/src/features/auth/components/password-validation.ts
@@ -1,0 +1,33 @@
+const MIN_LENGTH = 8;
+const SPECIAL_CHARACTERS = `!"#$%&'()*+,-./:;<=>?@[\\]^_\`{|}~`;
+
+export const PASSWORD_CRITERIA = {
+  LENGTH: `be at least ${MIN_LENGTH} characters long`,
+  LOWER: "contain at least one lowercase letter",
+  UPPER: "contain at least one uppercase letter",
+  DIGIT: "contain at least one digit",
+  SPECIAL: "contain at least one special character",
+} as const;
+
+export type PasswordCriteriaResult = {
+  [key: string]: boolean;
+};
+
+export default function PasswordValidation(password: string): {
+  isStrong: boolean;
+  criteria: PasswordCriteriaResult;
+} {
+  const criteria: PasswordCriteriaResult = {
+    [PASSWORD_CRITERIA.LENGTH]: password.length >= MIN_LENGTH,
+    [PASSWORD_CRITERIA.LOWER]: /[a-z]/.test(password),
+    [PASSWORD_CRITERIA.UPPER]: /[A-Z]/.test(password),
+    [PASSWORD_CRITERIA.DIGIT]: /\d/.test(password),
+    [PASSWORD_CRITERIA.SPECIAL]: new RegExp(
+      `[${SPECIAL_CHARACTERS.replace(/[\\^\-\]]/g, "\\$&")}]`,
+    ).test(password),
+  };
+
+  const isStrong = Object.values(criteria).every((passed) => passed);
+
+  return { isStrong, criteria };
+}


### PR DESCRIPTION
In this pull request, I refactored the password checking in `register` and `reset-password` such that it no longer calls the backend API to check if the password is strong enough. The password strength logic is now done on the client and I also added a message for when the password is strong enough.

<img width="1919" height="943" alt="image" src="https://github.com/user-attachments/assets/27dcf917-de59-4be2-a70a-8f382928bdf8" />