### PR TITLE
New event duration header

### DIFF
--- a/src/features/event/editor/advanced-options.tsx
+++ b/src/features/event/editor/advanced-options.tsx
@@ -94,7 +94,7 @@ function Options({ isEditing = false, errors }: AdvancedOptionsProps) {
         />
       </FormSelectorField>
 
-      <FormSelectorField label="Duration" htmlFor="duration-select" isVertical>
+      <FormSelectorField label="Intended Duration" htmlFor="duration-select" isVertical>
         <DurationSelector
           id="duration-select"
           value={eventRange.duration}


### PR DESCRIPTION
This pull request addresses issue #115. I changed the header for duration on the new event creation page from "Duration" to "Intended Duration".