### PR TITLE
Change danger button text style

### DIFF
--- a/src/features/button/components/base.tsx
+++ b/src/features/button/components/base.tsx
@@ -228,7 +228,7 @@ function getStyleClasses(
       switch (state) {
         case "rest":
           styleClasses = cn(
-            "bg-error text-violet",
+            "bg-error text-white font-semibold",
             "active:bg-[color-mix(in_oklab,var(--color-error)_100%,black_10%)]",
             "hover:bg-[color-mix(in_oklab,var(--color-error)_100%,white_10%)]",
           );


### PR DESCRIPTION
This changes the text on "danger" style buttons to use `text-white` and `font-semibold` instead of `text-violet`. It should have better contrast now.
