### PR TITLE
Fix merge protect logic

### DIFF
--- a/.github/workflows/merge-protect.yml
+++ b/.github/workflows/merge-protect.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   pull_request:
+    # Having edited here updates the check when changing the base branch
+    types: [synchronize, opened, reopened, edited]
 
 jobs:
   check_branch:


### PR DESCRIPTION
Previously, if you started a PR on main and then changed the base branch to fix it, the test would stay failed until you pushed a new commit. Now, it should update when changing the base branch.