### PR TITLE
Change remove self icon

### DIFF
--- a/src/features/event/results/attendees-panel.tsx
+++ b/src/features/event/results/attendees-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, startTransition } from "react";
 
-import { CheckIcon, EraserIcon, TrashIcon } from "@radix-ui/react-icons";
+import { CheckIcon, EraserIcon, ExitIcon } from "@radix-ui/react-icons";
 
 import { ResultsAvailabilityMap } from "@/core/availability/types";
 import ParticipantChip from "@/features/event/results/participant-chip";
@@ -96,7 +96,7 @@ export default function AttendeesPanel({
               className="text-red bg-red/15 hover:bg-red/25 active:bg-red/40 h-9 w-9 cursor-pointer rounded-full p-2 text-sm font-semibold"
               aria-label="Remove self"
             >
-              <TrashIcon className="h-5 w-5" />
+              <ExitIcon className="h-5 w-5" />
             </button>
           </ConfirmationDialog>
         )}


### PR DESCRIPTION
This changes the "remove self" button on the attendees panel to the exit icon.

<img width="336" height="252" alt="image" src="https://github.com/user-attachments/assets/7e8f2fa4-f54b-45d8-b7b5-a2b6e70c8837" />

This should make it clearer that you are leaving the event, rather than having an ambiguous trash icon.