### PR TITLE
Fix ESLint GitHub Action

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -2,7 +2,7 @@ name: Code Quality Check
 
 on:
   push:
-    branches: ["main", "main-preview"]
+    branches: ["main", "v*.*.*"] # Runs on pushes to main and version branches
   pull_request: # Runs on all PRs
 
 jobs:


### PR DESCRIPTION
The action was still passing even when linting errors were present.

The action was also trying to run on `main-preview` pushes, which we don't use anymore. It was updated to use our version branches instead.