### PR TITLE
Error page fixes

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -19,26 +19,26 @@ function getErrorDetails(error: Error & { digest?: string }) {
     message =
       "We're having trouble connecting to our servers. Please try again later.";
     status = 503;
-  }
+  } else {
+    try {
+      // Try to parse the message as JSON
+      const errorData = JSON.parse(error.message);
 
-  try {
-    // Try to parse the message as JSON
-    const errorData = JSON.parse(error.message);
-
-    // Check if it's our structured error
-    if (
-      typeof errorData === "object" &&
-      errorData !== null &&
-      "status" in errorData &&
-      "title" in errorData &&
-      "message" in errorData
-    ) {
-      status = errorData.status;
-      title = errorData.title;
-      message = errorData.message;
+      // Check if it's our structured error
+      if (
+        typeof errorData === "object" &&
+        errorData !== null &&
+        "status" in errorData &&
+        "title" in errorData &&
+        "message" in errorData
+      ) {
+        status = errorData.status;
+        title = errorData.title;
+        message = errorData.message;
+      }
+    } catch {
+      // If parsing fails, we just use the original message and default status
     }
-  } catch {
-    // If parsing fails, we just use the original message and default status
   }
 
   return { statusCode: String(status), title, message };


### PR DESCRIPTION
This PR makes a few small tweaks to the error page.

### Try Again Button Fix
The "Try Again" button only rerendered the client page, which wasn't helping. The error page only showed up when the server rendering failed. To fix this, the button now reloads the page on 500 errors.

### Server Component Message
The generic obscured error message honestly gives us a bad look on the production site. Now, if that message is detected, it instead shows a message that we can't connect to the backend, which is most often the culprit of those errors.