### PR TITLE
Fix default name autofill

### DIFF
--- a/src/features/event/availability/fetch-data.ts
+++ b/src/features/event/availability/fetch-data.ts
@@ -57,6 +57,9 @@ export async function fetchSelfAvailability(
     // 400 error is expected if the user has not submitted availability yet
     if (res.status !== 400) {
       handleErrorResponse(res.status, await res.json());
+    } else {
+      // Return no data since the user hasn't participated
+      return null;
     }
   }
 


### PR DESCRIPTION
This PR fixes a small bug where `initialData` in the painting page wouldn't be considered `null` when it should be.

This was because the error message received from the get self availability endpoint was being inserted into `initialData`, which would still show nothing on the grid but would confuse the default name population logic.