### PR TITLE
Toast height adjustment

### DIFF
--- a/src/features/system-feedback/toast/provider.tsx
+++ b/src/features/system-feedback/toast/provider.tsx
@@ -27,13 +27,22 @@ export default function ToastProvider({
 
     const handleResize = () => {
       const viewport = window.visualViewport;
-      const offset = window.innerHeight - viewport!.height;
-      setKeyboardHeight(offset > 0 ? offset : 0);
+
+      if (!viewport) {
+        setKeyboardHeight(0);
+        return;
+      }
+
+      const offset = window.innerHeight - viewport.height;
+
+      setKeyboardHeight(offset);
     };
 
-    window.visualViewport.addEventListener("resize", handleResize);
-    return () =>
+    window.visualViewport?.addEventListener("resize", handleResize);
+    handleResize();
+    return () => {
       window.visualViewport?.removeEventListener("resize", handleResize);
+    };
   }, []);
 
   const addToast = useCallback(


### PR DESCRIPTION
On mobile devices, when users are actively typing, toasts appear under the keyboard since the viewport doesn't adjust to the keyboard height automatically.

This PR adds a listener to track of offset of the vertical space available and actual height of the screen, adjusting the toast viewport location accordingly.