### PR TITLE
Host-only cookie hotfix

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,36 +2,36 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
-    const response = NextResponse.next();
+  const response = NextResponse.next();
 
-    const cookieNames = ["account_sess_token", "guest_sess_token"];
-    const hasLegacyCookies = cookieNames.some((name) =>
-        request.cookies.has(name)
-    );
+  const cookieNames = ["account_sess_token", "guest_sess_token"];
+  const hasLegacyCookies = cookieNames.some((name) =>
+    request.cookies.has(name)
+  );
 
-    // If the user has auth cookies...
-    if (hasLegacyCookies) {
+  // If the user has auth cookies...
+  if (hasLegacyCookies) {
 
-        // We defensively try to DELETE the Host-Only (legacy) cookies on every request.
-        // By setting Max-Age=0 and omitting the Domain attribute, we target the Host-Only version.
-        // The valid Domain cookie (.example.com) will remain untouched because the browser
-        // sees them as different scopes.
+    // We defensively try to DELETE the Host-Only (legacy) cookies on every request.
+    // By setting Max-Age=0 and omitting the Domain attribute, we target the Host-Only version.
+    // The valid Domain cookie (.example.com) will remain untouched because the browser
+    // sees them as different scopes.
 
-        // This logic can only be removed AFTER February 15, 2027 (one year from now) just
-        // to be safe, since long session cookies have a 1 year lifetime
+    // This logic can only be removed AFTER February 15, 2027 (one year from now) just
+    // to be safe, since long session cookies have a 1 year lifetime
 
-        cookieNames.forEach((name) => {
-            response.headers.append(
-                "Set-Cookie",
-                `${name}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`
-            );
-        });
-    }
+    cookieNames.forEach((name) => {
+      response.headers.append(
+        "Set-Cookie",
+        `${name}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`
+      );
+    });
+  }
 
-    return response;
+  return response;
 }
 
 export const config = {
-    // Run on all pages, but skip static files and API routes
-    matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+  // Run on all pages, but skip static files and API routes
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
 };


### PR DESCRIPTION
The removal of proxies caused some big problems with session cookies. This PR just introduces logic to delete the old legacy cookies before they start causing more problems.