### PR TITLE
Remove user-supplied value from cookies

### DIFF
--- a/backend/api/auth/views.py
+++ b/backend/api/auth/views.py
@@ -268,7 +268,10 @@ def login(request):
             )
             # Refresh the session token cookie
             set_session_cookie(
-                response, ACCOUNT_COOKIE_NAME, acct_token, session.is_extended
+                response,
+                ACCOUNT_COOKIE_NAME,
+                session.session_token,
+                session.is_extended,
             )
             return response
         except UserSession.DoesNotExist:

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -167,7 +167,10 @@ def check_auth(func):
                 response = func(request, *args, **kwargs)
                 # Intercept the response to refresh the session token cookie
                 set_session_cookie(
-                    response, ACCOUNT_COOKIE_NAME, acct_token, session.is_extended
+                    response,
+                    ACCOUNT_COOKIE_NAME,
+                    session.session_token,
+                    session.is_extended,
                 )
                 return response
             except UserSession.DoesNotExist:
@@ -196,7 +199,9 @@ def check_auth(func):
                 request.user = session.user_account
                 # Run the function
                 response = func(request, *args, **kwargs)
-                set_session_cookie(response, GUEST_COOKIE_NAME, guest_token, True)
+                set_session_cookie(
+                    response, GUEST_COOKIE_NAME, session.session_token, True
+                )
             except UserSession.DoesNotExist:
                 logger.info("Guest session expired.")
                 # Do NOT create a new guest account
@@ -262,7 +267,10 @@ def require_auth(func):
                 response = func(request, *args, **kwargs)
                 # Intercept the response to refresh the session token cookie
                 set_session_cookie(
-                    response, ACCOUNT_COOKIE_NAME, acct_token, session.is_extended
+                    response,
+                    ACCOUNT_COOKIE_NAME,
+                    session.session_token,
+                    session.is_extended,
                 )
                 return response
             except UserSession.DoesNotExist:
@@ -291,7 +299,9 @@ def require_auth(func):
                 request.user = session.user_account
                 # Run the function
                 response = func(request, *args, **kwargs)
-                set_session_cookie(response, GUEST_COOKIE_NAME, guest_token, True)
+                set_session_cookie(
+                    response, GUEST_COOKIE_NAME, session.session_token, True
+                )
             except UserSession.DoesNotExist:
                 logger.info("Guest session expired. Creating a new guest account...")
                 # Check guest creation rate limit
@@ -436,7 +446,10 @@ def require_account_auth(func):
                 response = func(request, *args, **kwargs)
                 # Intercept the response to refresh the session token cookie
                 set_session_cookie(
-                    response, ACCOUNT_COOKIE_NAME, acct_token, session.is_extended
+                    response,
+                    ACCOUNT_COOKIE_NAME,
+                    session.session_token,
+                    session.is_extended,
                 )
                 return response
             except UserSession.DoesNotExist:


### PR DESCRIPTION
While this isn't a big concern, it was brought up by dependabot in the last PR.

It mentioned that we set our cookie values to the value supplied by the user, which is technically true, but those values are validated in the database before being set.

Just to be extra safe here, I changed the session cookie value to use the value returned from the database instead.