### PR TITLE
Remove guest cleanup

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta
 
+from celery import shared_task
+from django.db.models import Q
+
 from api.models import PasswordResetToken, UnverifiedUserAccount, UserSession
 from api.settings import (
     EMAIL_CODE_EXP_SECONDS,
@@ -7,8 +10,6 @@ from api.settings import (
     PWD_RESET_EXP_SECONDS,
     SESS_EXP_SECONDS,
 )
-from celery import shared_task
-from django.db.models import Q
 
 
 def session_cleanup():


### PR DESCRIPTION
This PR removes the scheduled task that removes guests without sessions.

I didn't realize that it would completely delete everything related to those users, and combined with the recent session deletion this had a cascading effect of deleting most of the data on our site.

Oops, my bad. That's a beta release for you.