### PR TITLE
Fix failing Python CodeQL check

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,10 +45,16 @@ jobs:
         include:
           - language: actions
             build-mode: none
+            paths:
+              - ".github/workflows"
           - language: javascript-typescript
             build-mode: none
+            paths:
+              - "frontend"
           - language: python
             build-mode: none
+            paths:
+              - "backend"
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -73,6 +79,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          source-root: ${{ matrix.paths[0] }}
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
The last 2 PRs have had failing CodeQL checks for Python, due to an issue with an invalid path. This PR introduces explicit for each language, to hopefully fix this problem.