### PR TITLE
Update base toast duration

### DIFF
--- a/frontend/src/features/system-feedback/toast/base.tsx
+++ b/frontend/src/features/system-feedback/toast/base.tsx
@@ -27,7 +27,7 @@ export default function BaseToast({
   icon,
   backgroundColor,
   textColor,
-  duration = 3000,
+  duration = 5000,
   isPersistent = false,
   isPaused,
 }: BaseToastProps) {


### PR DESCRIPTION
This PR just increases the base duration of toasts from 3 to 5 seconds. This is the default from Radix, and I read somewhere (I forgot where) that at least 5 seconds is recommended. This gives users enough time to notice the toast, then comfortably read the content.

I considered adding a dynamic duration based on the length of the content, but all of our toasts are quite short. It was also messing with the progress bar in a way I didn't feel like dealing with.

For more important toasts, they can either be persistent or have a custom duration set with `ToastOptions`.