### PR TITLE
Fix time column chip overlap with `MobileFooterTray`

### DIFF
--- a/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
@@ -337,7 +337,10 @@ export default function ClientPage({
         />
       </div>
 
-      <MobileFooterTray buttons={[cancelButton, submitButton]} />
+      {/* This z-index is necessary to avoid the time column overlapping */}
+      <div className="z-10">
+        <MobileFooterTray buttons={[cancelButton, submitButton]} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/event/editor/editor.tsx
+++ b/frontend/src/features/event/editor/editor.tsx
@@ -199,11 +199,14 @@ function EventEditorContent({ type, initialData }: EventEditorProps) {
       </div>
       <div className="h-16 md:hidden" />
 
-      <MobileFooterTray
-        buttons={
-          type === "edit" ? [cancelButton, submitButton] : [submitButton]
-        }
-      />
+      {/* This z-index is necessary to avoid the time column overlapping */}
+      <div className="z-10">
+        <MobileFooterTray
+          buttons={
+            type === "edit" ? [cancelButton, submitButton] : [submitButton]
+          }
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This fixes the bug in #173.

As far as the implementation, I would have loved to add a z-index to the component itself and never have to worry about it again, but unfortunately that would be in a different stacking context from the problematic element here.