### PR TITLE
Adjust database connection lifetime for development

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -73,7 +73,7 @@ DATABASES = {
         "PASSWORD": env("DB_PASSWORD"),
         "HOST": env("DB_HOST"),
         "PORT": env("DB_PORT"),
-        "CONN_MAX_AGE": 600,
+        "CONN_MAX_AGE": 0 if DEBUG else 600,  # Don't persist connections in development
     }
 }
 


### PR DESCRIPTION
I kept running into this issue where Supabase would give a "max connected clients" error in development. This should hopefully fix that.

The value stays the same in production to reuse connections when using Gunicorn.