### PR TITLE
`.env.example` comment fix

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 # Database credentials
-DB_NAME=name # Look for "database" or "schema"
+# Look for "database" or "schema" for DB_NAME
+DB_NAME=name
 DB_USER=user
 DB_PASSWORD=password
 DB_HOST=hostname


### PR DESCRIPTION
This PR just moves a comment in `.env.example` off the same line as the `DB_NAME` field.

For some reason, the actual `.env` parsing during runtime doesn't like this and interprets the comment as part of the value, causing an error.