### PR TITLE
Bold event titles

### DIFF
--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -94,7 +94,7 @@ export default function ClientPage({
       <HeaderSpacer />
       <div className="flex flex-col justify-between gap-2 md:flex-row">
         <div className="flex flex-1 justify-between">
-          <h1 className="text-2xl">{eventName}</h1>
+          <h1 className="text-2xl font-bold">{eventName}</h1>
           <EventInfoDrawer eventRange={eventRange} timezone={timezone} />
         </div>
         <div className="flex flex-wrap items-start justify-end gap-2">

--- a/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
@@ -259,7 +259,7 @@ export default function ClientPage({
       {/* Header and Button Row */}
       <div className="flex w-full flex-wrap justify-between md:flex-row">
         <div className="flex flex-1 justify-between">
-          <h1 className="text-2xl">{eventName}</h1>
+          <h1 className="text-2xl font-bold">{eventName}</h1>
           <EventInfoDrawer eventRange={eventRange} timezone={timeZone} />
         </div>
         <div className="hidden items-center gap-2 md:flex">


### PR DESCRIPTION
To keep the style consistent between all pages with a title, I added `font-bold` to the titles on event pages (painting and results).