### PR TITLE
New event button style changes

### DIFF
--- a/frontend/src/components/header/new-event-button.tsx
+++ b/frontend/src/components/header/new-event-button.tsx
@@ -13,7 +13,7 @@ export default function NewEventButton() {
     return null;
   }
 
-  let style: ButtonStyle = "secondary";
+  let style: ButtonStyle = "frosted glass inset";
 
   if (pathname === "/dashboard" || pathname === "/") {
     style = "primary";


### PR DESCRIPTION
Currently, the new event button is always the bright accent color in the header, meant to draw attention. However, this doesn't make as much sense on pages like results and painting, where your focus should be on the current event.

This PR changes that button to use the `frosted glass inset` style on every page but the dashboard and landing pages. This means login pages also have the `frosted glass inset` style on that button, where you should be focused on auth-related stuff anyway.

We initially discussed using the semi-transparent style, but after trying it I thought it didn't look good on the frosted glass. See below.

<img width="407" height="123" alt="2026-02-26_21-15-36" src="https://github.com/user-attachments/assets/02e82aea-d106-4071-9c74-8c7d56645b30" />

<img width="402" height="107" alt="image" src="https://github.com/user-attachments/assets/f9cd8724-d7eb-4978-9f18-ac48f2f0ae43" />