### PR TITLE
Clean up unused imports

### DIFF
--- a/backend/api/auth/views.py
+++ b/backend/api/auth/views.py
@@ -31,10 +31,8 @@ from api.settings import (
     BASE_URL,
     EMAIL_CODE_EXP_SECONDS,
     GENERIC_ERR_RESPONSE,
-    LONG_SESS_EXP_SECONDS,
     PWD_RESET_EXP_SECONDS,
     SEND_EMAILS,
-    SESS_EXP_SECONDS,
 )
 from api.utils import (
     MessageOutputSerializer,

--- a/backend/api/dashboard/views.py
+++ b/backend/api/dashboard/views.py
@@ -1,5 +1,4 @@
 import logging
-from zoneinfo import ZoneInfo
 
 from django.db import DatabaseError
 from django.db.models import Prefetch, Q

--- a/backend/api/event/utils.py
+++ b/backend/api/event/utils.py
@@ -2,7 +2,7 @@ import logging
 import random
 import re
 import string
-from datetime import datetime, time, timedelta
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from django.db.models import Prefetch

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,7 +1,5 @@
 from django.urls import include, path
 
-from . import views
-
 urlpatterns = [
     path("docs/", include("api.docs.urls")),
     path("auth/", include("api.auth.urls")),


### PR DESCRIPTION
There were just a few unused imports across the backend. That's it.

The Python linter just isn't as strict as ESLint when it comes to that. Maybe we can change that later.