### PR TITLE
Double Gunicorn workers

### DIFF
--- a/backend/ecosystem.config.js
+++ b/backend/ecosystem.config.js
@@ -6,7 +6,7 @@ module.exports = {
             name: "plancake-api",
             cwd: __dirname,
             script: "./.venv/bin/python",
-            args: "-m gunicorn api.wsgi --bind 127.0.0.1:8000",
+            args: "-m gunicorn api.wsgi --workers 2 --bind 127.0.0.1:8000",
             instances: 1,
             autorestart: true,
             max_memory_restart: "250M",


### PR DESCRIPTION
This just increases the Gunicorn worker count from 1 to 2. It should allow for concurrent requests, for however much traffic we're really going to get.