### PR TITLE
Prevent autofill attempt after setting nickname

### DIFF
--- a/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
@@ -124,7 +124,10 @@ export default function ClientPage({
   useEffect(() => {
     if (nameInitialized.current) return;
     if (loginState !== "logged_in") return;
-    if (!accountDetails || !accountDetails.defaultName) return;
+    if (!accountDetails || !accountDetails.defaultName) {
+      nameInitialized.current = true; // don't try again after setting the name
+      return;
+    }
 
     const newName = accountDetails.defaultName;
     setDisplayName(newName);


### PR DESCRIPTION
This PR fixes #232, where the "Name Autofilled" toast would show when saving a nickname on availability submission.