### PR TITLE
Fix dialog blur on Safari

### DIFF
--- a/frontend/src/features/system-feedback/confirmation/base.tsx
+++ b/frontend/src/features/system-feedback/confirmation/base.tsx
@@ -115,7 +115,7 @@ export default function ConfirmationDialog({
         <Dialog.Content
           onEscapeKeyDown={(event) => event.stopPropagation()}
           className={cn(
-            "dialog-content fixed left-1/2 top-1/2 z-40 -translate-x-1/2 -translate-y-1/2",
+            "dialog-content fixed inset-0 z-40 m-auto",
             "bg-panel rounded-3xl p-6 shadow-md focus:outline-none",
             "h-fit w-3/4 md:w-fit md:max-w-3xl",
           )}


### PR DESCRIPTION
Because of the usage of `translate` in the dialog, it was messing with the Safari renderer and causing the dialog to be blurry. This approach was replaced with something simpler which should be more robust.

It was tested on Chrome and Safari and looks normal now.

Closes #196.