### PR TITLE
Update semi-transparent button text color

### DIFF
--- a/frontend/src/features/button/components/base.tsx
+++ b/frontend/src/features/button/components/base.tsx
@@ -245,7 +245,7 @@ function getStyleClasses(
       switch (state) {
         case "rest":
           styleClasses =
-            "text-accent font-bold bg-accent/15 hover:bg-accent/25 active:bg-accent/40";
+            "text-accent-text font-bold bg-accent/15 hover:bg-accent/25 active:bg-accent/40";
           break;
         case "loading":
           styleClasses = "font-bold bg-accent/20";
@@ -255,7 +255,7 @@ function getStyleClasses(
             "font-bold text-[#ffffff] dark:text-gray-400 bg-gray-200 dark:bg-gray-400/25";
           break;
       }
-      spinnerClasses = "border-accent";
+      spinnerClasses = "border-accent-text";
       break;
     case "transparent":
       switch (state) {


### PR DESCRIPTION
When changing the accent color, we updated all the selectors to have `text-accent-text` for more contrast.

Since semi-transparent buttons were introduced in the minor version branch, we didn't see how they looked with the new accent color. It's now updated for better contrast against the transparent accent-colored background.

This is how it looks now (these buttons are just used for example, they are not changed in this PR):
<img width="667" height="463" alt="image" src="https://github.com/user-attachments/assets/86f37518-77e3-495a-800a-6ecad3c16f53" />