### PR TITLE
Add `--color-black` definition

### DIFF
--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -3,6 +3,7 @@
 /* COLOR PALETTE */
 @theme {
   --color-white: oklch(0.9702 0 0);
+  --color-black: oklch(0 0 0);
   --color-violet: oklch(0.368 0.0393 288.29);
   --color-bone: oklch(0.904 0.0293 82.59);
   --color-red: oklch(0.6909 0.1987 23.91);


### PR DESCRIPTION
Just to SHUT COPILOT UP DURING ALL THE PR REVIEWS. :)

It's defined as a base color in Tailwind, which is why it's been working, but I don't think Copilot knows that.