### PR TITLE
Add panel background to weekday row

### DIFF
--- a/frontend/src/features/dashboard/components/weekday-row.tsx
+++ b/frontend/src/features/dashboard/components/weekday-row.tsx
@@ -10,7 +10,7 @@ export default function WeekdayRow({
   endWeekday,
 }: WeekdayRowProps) {
   return (
-    <div className={`flex w-full`}>
+    <div className="bg-panel flex w-fit rounded-full">
       {["S", "M", "T", "W", "T", "F", "S"].map((initial, index) => (
         <WeekdayRowIcon
           key={index}


### PR DESCRIPTION
Now that the event details panel is gone, we can add `bg-panel` to the `WeekdayRow` without worrying about the colors conflicting. It's now only used on the dashboard.

<img width="350" height="506" alt="image" src="https://github.com/user-attachments/assets/82a88e76-7751-4ebc-80ca-aed15aa591bb" />