### PR TITLE
Fix hovered timeslot format on weekday event

### DIFF
--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -30,12 +30,7 @@ export default function ClientPage({
   initialAvailabilityData: ResultsInformation;
 }) {
   return (
-    <ResultsProvider
-      initialData={{
-        ...initialAvailabilityData,
-        eventType: eventData.eventRange.type,
-      }}
-    >
+    <ResultsProvider initialData={initialAvailabilityData}>
       <EventResults eventData={eventData} />
     </ResultsProvider>
   );

--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -30,7 +30,12 @@ export default function ClientPage({
   initialAvailabilityData: ResultsInformation;
 }) {
   return (
-    <ResultsProvider initialData={initialAvailabilityData}>
+    <ResultsProvider
+      initialData={{
+        ...initialAvailabilityData,
+        eventType: eventData.eventRange.type,
+      }}
+    >
       <EventResults eventData={eventData} />
     </ResultsProvider>
   );

--- a/frontend/src/app/(event)/[event-code]/page.tsx
+++ b/frontend/src/app/(event)/[event-code]/page.tsx
@@ -73,6 +73,7 @@ export default async function Page({ params }: EventCodePageProps) {
         timeslots,
       }}
       initialAvailabilityData={{
+        eventType: eventRange.type,
         participants: availabilityData.participants,
         availability: availabilityData.availability,
         currentUser: availabilityData.user_display_name,

--- a/frontend/src/features/event/results/attendee-panel/panel-header.tsx
+++ b/frontend/src/features/event/results/attendee-panel/panel-header.tsx
@@ -48,14 +48,10 @@ export default function PanelHeader({
     return eventType === "weekday"
       ? date.toLocaleString(undefined, {
           weekday: "long",
+          hour: "numeric",
+          minute: "numeric",
           timeZone: timezone,
-        }) +
-          " at " +
-          date.toLocaleString(undefined, {
-            hour: "numeric",
-            minute: "numeric",
-            timeZone: timezone,
-          })
+        })
       : date.toLocaleString(undefined, {
           weekday: "short",
           month: "short",

--- a/frontend/src/features/event/results/attendee-panel/panel-header.tsx
+++ b/frontend/src/features/event/results/attendee-panel/panel-header.tsx
@@ -20,6 +20,7 @@ export default function PanelHeader({
   isCollapsed = false,
 }: PanelHeaderProps) {
   const {
+    eventType,
     hoveredSlot,
     participants,
     filteredAvailabilities,
@@ -40,6 +41,30 @@ export default function PanelHeader({
   const hasSelection = selectedParticipants.length > 0;
   const showSelfRemove =
     !isCreator && currentUser && participants.includes(currentUser);
+
+  const formatHoveredSlot = () => {
+    const date = new Date(hoveredSlot!);
+
+    return eventType === "weekday"
+      ? date.toLocaleString(undefined, {
+          weekday: "long",
+          timeZone: timezone,
+        }) +
+          " at " +
+          date.toLocaleString(undefined, {
+            hour: "numeric",
+            minute: "numeric",
+            timeZone: timezone,
+          })
+      : date.toLocaleString(undefined, {
+          weekday: "short",
+          month: "short",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          timeZone: timezone,
+        });
+  };
 
   return (
     <div
@@ -65,16 +90,9 @@ export default function PanelHeader({
           <span className="text-sm opacity-75">
             {isRemoving
               ? `Select to remove`
-              : hoveredSlot !== null
-                ? new Date(hoveredSlot).toLocaleString(undefined, {
-                    weekday: "short",
-                    month: "short",
-                    day: "numeric",
-                    hour: "numeric",
-                    minute: "numeric",
-                    timeZone: timezone,
-                  })
-                : "Hover grid for availability"}
+              : hoveredSlot === null
+                ? "Hover grid for availability"
+                : formatHoveredSlot()}
           </span>
         )}
       </div>

--- a/frontend/src/features/event/results/lib/types.ts
+++ b/frontend/src/features/event/results/lib/types.ts
@@ -2,6 +2,7 @@ import { AllAvailability } from "@/lib/utils/api/types";
 
 export type ResultsInformation = {
   eventCode: string;
+  eventType: string;
   isCreator: boolean;
   participants: AllAvailability["participants"];
   availability: AllAvailability["availability"];

--- a/frontend/src/features/event/results/lib/types.ts
+++ b/frontend/src/features/event/results/lib/types.ts
@@ -1,8 +1,9 @@
+import { EventType } from "@/core/event/types";
 import { AllAvailability } from "@/lib/utils/api/types";
 
 export type ResultsInformation = {
   eventCode: string;
-  eventType: string;
+  eventType: EventType;
   isCreator: boolean;
   participants: AllAvailability["participants"];
   availability: AllAvailability["availability"];

--- a/frontend/src/features/event/results/lib/use-results.ts
+++ b/frontend/src/features/event/results/lib/use-results.ts
@@ -165,6 +165,7 @@ export function useEventResults(initialData: ResultsInformation) {
 
   return {
     // Data
+    eventType: initialData.eventType,
     participants: optimisticParticipants,
     availabilities: optimisticAvailabilities,
     filteredAvailabilities,


### PR DESCRIPTION
An oversight on my part, I forgot to test the new attendee panel header with weekday events. This adds a different format for that event type, only showing the weekday and the time instead of the underlying date representation.

To accomplish this, `eventType` was added to the event results provider.