### PR TITLE
Mobile availability add banner fix

### DIFF
--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -20,6 +20,7 @@ import ResultsDrawer from "@/features/event/results/drawer";
 import { ResultsInformation } from "@/features/event/results/lib/types";
 import HeaderSpacer from "@/features/header/components/header-spacer";
 import { useHeaderSize } from "@/features/header/context";
+import useCheckMobile from "@/lib/hooks/use-check-mobile";
 import { cn } from "@/lib/utils/classname";
 
 export default function ClientPage({
@@ -85,6 +86,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
     timeslots,
     eventRange.type === "weekday",
     currentUser !== null,
+    useCheckMobile(),
   );
 
   /* BUTTONS */

--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -20,7 +20,6 @@ import ResultsDrawer from "@/features/event/results/drawer";
 import { ResultsInformation } from "@/features/event/results/lib/types";
 import HeaderSpacer from "@/features/header/components/header-spacer";
 import { useHeaderSize } from "@/features/header/context";
-import useCheckMobile from "@/lib/hooks/use-check-mobile";
 import { cn } from "@/lib/utils/classname";
 
 export default function ClientPage({
@@ -86,7 +85,6 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
     timeslots,
     eventRange.type === "weekday",
     currentUser !== null,
-    useCheckMobile(),
   );
 
   /* BUTTONS */

--- a/frontend/src/features/event/results/banners.tsx
+++ b/frontend/src/features/event/results/banners.tsx
@@ -9,7 +9,6 @@ export function getResultBanners(
   timeslots: Date[],
   isWeekEvent: boolean,
   participated: boolean,
-  isMobile: boolean,
 ) {
   if (
     !isWeekEvent &&
@@ -26,11 +25,8 @@ export function getResultBanners(
         subtitle="No one has submitted availability!"
         showPing
       >
-        <p>
-          {isMobile
-            ? MESSAGES.INFO_ADD_AVAILABILITY_MOBILE
-            : MESSAGES.INFO_ADD_AVAILABILITY}
-        </p>
+        <p className="md:hidden">{MESSAGES.INFO_ADD_AVAILABILITY_MOBILE}</p>
+        <p className="hidden md:block">{MESSAGES.INFO_ADD_AVAILABILITY}</p>
       </Banner>
     );
   } else if (!hasMutualAvailability(availabilities, participants)) {
@@ -48,11 +44,8 @@ export function getResultBanners(
   } else if (!participated) {
     return (
       <Banner type="info" subtitle="Don't be a stranger!" showPing>
-        <p>
-          {isMobile
-            ? MESSAGES.INFO_ADD_AVAILABILITY_MOBILE
-            : MESSAGES.INFO_ADD_AVAILABILITY}
-        </p>
+        <p className="md:hidden">{MESSAGES.INFO_ADD_AVAILABILITY_MOBILE}</p>
+        <p className="hidden md:block">{MESSAGES.INFO_ADD_AVAILABILITY}</p>
       </Banner>
     );
   }

--- a/frontend/src/features/event/results/banners.tsx
+++ b/frontend/src/features/event/results/banners.tsx
@@ -9,6 +9,7 @@ export function getResultBanners(
   timeslots: Date[],
   isWeekEvent: boolean,
   participated: boolean,
+  isMobile: boolean,
 ) {
   if (
     !isWeekEvent &&
@@ -25,7 +26,11 @@ export function getResultBanners(
         subtitle="No one has submitted availability!"
         showPing
       >
-        <p>{MESSAGES.INFO_ADD_AVAILABILITY}</p>
+        <p>
+          {isMobile
+            ? MESSAGES.INFO_ADD_AVAILABILITY_MOBILE
+            : MESSAGES.INFO_ADD_AVAILABILITY}
+        </p>
       </Banner>
     );
   } else if (!hasMutualAvailability(availabilities, participants)) {
@@ -43,7 +48,11 @@ export function getResultBanners(
   } else if (!participated) {
     return (
       <Banner type="info" subtitle="Don't be a stranger!" showPing>
-        <p>{MESSAGES.INFO_ADD_AVAILABILITY}</p>
+        <p>
+          {isMobile
+            ? MESSAGES.INFO_ADD_AVAILABILITY_MOBILE
+            : MESSAGES.INFO_ADD_AVAILABILITY}
+        </p>
       </Banner>
     );
   }

--- a/frontend/src/lib/messages.ts
+++ b/frontend/src/lib/messages.ts
@@ -56,6 +56,7 @@ export const MESSAGES = {
   INFO_NOT_LOGGED_IN: "You are not logged in.",
   INFO_EVENT_PASSED: "All dates in this event have passed.",
   INFO_ADD_AVAILABILITY: "Add your availability by clicking the button above.",
+  INFO_ADD_AVAILABILITY_MOBILE: "Add your availability by clicking the button below.",
   INFO_COPY_SHARE_LINK: "Copy and share the link so others can join!",
   INFO_NO_MUTUAL_AVAILABILITY: "There is no time where everyone is available.",
 };


### PR DESCRIPTION
The message on the results page banner directed users to click the button above to add their availability. Since reworking the mobile results page, that is no longer true. There is now a check for mobile that modifies this message.