### PR TITLE
Add share button

### DIFF
--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from "react";
 
-import { PencilIcon, SquarePenIcon } from "lucide-react";
+import { PencilIcon, ShareIcon, SquarePenIcon } from "lucide-react";
 
 import CopyToastButton from "@/components/copy-toast-button";
 import KebabMenu from "@/components/kebab-menu";
 import { EventInformation } from "@/core/event/types";
+import ActionButton from "@/features/button/components/action";
 import LinkButton from "@/features/button/components/link";
 import ScheduleGrid from "@/features/event/grid/grid";
 import AttendeesPanel from "@/features/event/results/attendee-panel/panel";
@@ -20,6 +21,7 @@ import ResultsDrawer from "@/features/event/results/drawer";
 import { ResultsInformation } from "@/features/event/results/lib/types";
 import HeaderSpacer from "@/features/header/components/header-spacer";
 import { useHeaderSize } from "@/features/header/context";
+import { useToast } from "@/features/system-feedback";
 import { cn } from "@/lib/utils/classname";
 
 export default function ClientPage({
@@ -56,6 +58,9 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
     eventRange,
     timeslots,
   } = eventData;
+
+  /* TOAST PROVIDER */
+  const { addToast } = useToast();
 
   /* TIMEZONE HANDLING */
   const handleTZChange = (newTZ: string | number) => {
@@ -106,6 +111,30 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
     />
   );
 
+  const shareButton = (buttonStyle: "frosted glass inset" | "secondary") => (
+    <ActionButton
+      buttonStyle={buttonStyle}
+      icon={<ShareIcon />}
+      label="Share Event"
+      onClick={async () => {
+        try {
+          await navigator.share({
+            title: eventTitle,
+            url: window.location.href,
+          });
+        } catch (error) {
+          // An error is thrown if sharing is cancelled, ignore that
+          if (error instanceof Error && error.name !== "AbortError") {
+            addToast(
+              "error",
+              "Sharing is not supported on this browser, sorry!",
+            );
+          }
+        }
+      }}
+    />
+  );
+
   const copyButton = (buttonStyle: "frosted glass inset" | "secondary") => (
     <CopyToastButton code={eventCode} buttonStyle={buttonStyle} />
   );
@@ -121,12 +150,14 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
         <div className="md:hidden">
           <KebabMenu>
             {isCreator && editButton("frosted glass inset")}
+            {shareButton("frosted glass inset")}
             {copyButton("frosted glass inset")}
           </KebabMenu>
         </div>
 
         <div className="ml-auto hidden flex-wrap justify-end gap-2 md:flex">
           {isCreator && editButton("secondary")}
+          {shareButton("secondary")}
           {copyButton("secondary")}
           {paintingButton}
         </div>

--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -22,6 +22,7 @@ import { ResultsInformation } from "@/features/event/results/lib/types";
 import HeaderSpacer from "@/features/header/components/header-spacer";
 import { useHeaderSize } from "@/features/header/context";
 import { useToast } from "@/features/system-feedback";
+import { MESSAGES } from "@/lib/messages";
 import { cn } from "@/lib/utils/classname";
 
 export default function ClientPage({
@@ -111,29 +112,33 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
     />
   );
 
-  const shareButton = (buttonStyle: "frosted glass inset" | "secondary") => (
-    <ActionButton
-      buttonStyle={buttonStyle}
-      icon={<ShareIcon />}
-      label="Share Event"
-      onClick={async () => {
-        try {
-          await navigator.share({
-            title: eventTitle,
-            url: window.location.href,
-          });
-        } catch (error) {
-          // An error is thrown if sharing is cancelled, ignore that
-          if (error instanceof Error && error.name !== "AbortError") {
-            addToast(
-              "error",
-              "Sharing is not supported on this browser, sorry!",
-            );
-          }
-        }
-      }}
-    />
-  );
+  const shareButton = (buttonStyle: "frosted glass inset" | "secondary") => {
+    if (typeof navigator !== "undefined" && !navigator.share) {
+      // Don't show the button if sharing isn't supported
+      return null;
+    } else {
+      return (
+        <ActionButton
+          buttonStyle={buttonStyle}
+          icon={<ShareIcon />}
+          label="Share Event"
+          onClick={async () => {
+            try {
+              await navigator.share({
+                title: eventTitle,
+                url: window.location.href,
+              });
+            } catch (error) {
+              // An error is thrown if sharing is cancelled, ignore that
+              if (error instanceof Error && error.name !== "AbortError") {
+                addToast("error", MESSAGES.ERROR_GENERIC);
+              }
+            }
+          }}
+        />
+      );
+    }
+  };
 
   const copyButton = (buttonStyle: "frosted glass inset" | "secondary") => (
     <CopyToastButton code={eventCode} buttonStyle={buttonStyle} />

--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -39,6 +39,8 @@ export default function ClientPage({
   );
 }
 
+type HeaderButtonStyle = "frosted glass inset" | "secondary";
+
 function EventResults({ eventData }: { eventData: EventInformation }) {
   const {
     hoveredSlot,
@@ -103,7 +105,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
     />
   );
 
-  const editButton = (buttonStyle: "frosted glass inset" | "secondary") => (
+  const editButton = (buttonStyle: HeaderButtonStyle) => (
     <LinkButton
       buttonStyle={buttonStyle}
       icon={<PencilIcon />}
@@ -112,7 +114,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
     />
   );
 
-  const shareButton = (buttonStyle: "frosted glass inset" | "secondary") => {
+  const shareButton = (buttonStyle: HeaderButtonStyle) => {
     // Check if sharing is supported
     if (typeof navigator !== "undefined" && !navigator.share) {
       /* This condition means it will be rendered until mounted on the client, then it
@@ -148,7 +150,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
     }
   };
 
-  const copyButton = (buttonStyle: "frosted glass inset" | "secondary") => (
+  const copyButton = (buttonStyle: HeaderButtonStyle) => (
     <CopyToastButton code={eventCode} buttonStyle={buttonStyle} />
   );
 

--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -113,8 +113,16 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
   );
 
   const shareButton = (buttonStyle: "frosted glass inset" | "secondary") => {
+    // Check if sharing is supported
     if (typeof navigator !== "undefined" && !navigator.share) {
-      // Don't show the button if sharing isn't supported
+      /* This condition means it will be rendered until mounted on the client, then it
+       * disappears if not supported. There are more browsers that support the API than
+       * don't, so this is a better trade-off than having the button appear after initial
+       * mount on supported browsers.
+       *
+       * This also won't be visible on mobile anyway, since the buttons are hidden in the
+       * kebab menu.
+       */
       return null;
     } else {
       return (


### PR DESCRIPTION
This PR adds a share button to event results.

Keep in mind that sharing only works on secure connections or localhost, in the same way that the copy link button does. If you want to test from a phone, you have to use the `--experimental-https` flag or test from a Codespace instead of LAN.