### PR TITLE
Change desktop grid to scrollable

### DIFF
--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -160,7 +160,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
         <div
           className={cn(
             "hidden md:block",
-            "fixed bottom-1 left-0 z-10 w-full shrink-0 px-6",
+            "z-10 w-full shrink-0",
             "relative bottom-auto left-auto w-80 space-y-4 px-0",
           )}
         >

--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -111,7 +111,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
   );
 
   return (
-    <div className="flex flex-col space-y-4 pl-6 pr-6">
+    <div className="flex flex-col space-y-4 pl-6 pr-6 md:h-screen">
       <HeaderSpacer />
 
       {/* Header */}
@@ -134,7 +134,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
 
       <div className="md:hidden">{banners}</div>
 
-      <div className="flex h-fit flex-col md:flex-row md:gap-4">
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row md:gap-4">
         <ScheduleGrid
           mode="view"
           isWeekdayEvent={eventRange.type === "weekday"}

--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -165,7 +165,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
           )}
         >
           {banners}
-          <div className="flex max-h-[calc(100vh-8rem)] flex-col gap-y-4">
+          <div className="flex max-h-[calc(100vh-18rem)] flex-col gap-y-4">
             <AttendeesPanel />
             <div className="bg-panel shrink-0 rounded-3xl p-6 text-sm">
               <DisplaySettings

--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -19,7 +19,6 @@ import DisplaySettings from "@/features/event/results/display-settings";
 import ResultsDrawer from "@/features/event/results/drawer";
 import { ResultsInformation } from "@/features/event/results/lib/types";
 import HeaderSpacer from "@/features/header/components/header-spacer";
-import { useHeaderSize } from "@/features/header/context";
 import { cn } from "@/lib/utils/classname";
 
 export default function ClientPage({
@@ -74,9 +73,6 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
 
     return drawerSnap;
   };
-
-  /* HEADER SPACING */
-  const { topMarginClass } = useHeaderSize();
 
   /* BANNERS */
   const banners = getResultBanners(
@@ -169,12 +165,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
           )}
         >
           {banners}
-          <div
-            className={cn(
-              "sticky flex max-h-[calc(100vh-8rem)] flex-col gap-y-4",
-              topMarginClass,
-            )}
-          >
+          <div className="flex max-h-[calc(100vh-8rem)] flex-col gap-y-4">
             <AttendeesPanel />
             <div className="bg-panel shrink-0 rounded-3xl p-6 text-sm">
               <DisplaySettings

--- a/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
@@ -266,12 +266,7 @@ export default function ClientPage({
       {/* Main Content */}
       <div className="mb-12 flex min-h-0 flex-1 flex-col gap-4 md:mb-0 md:flex-row">
         {/* Left Panel */}
-        <div
-          className={cn(
-            topMarginClass,
-            "h-fit w-full shrink-0 space-y-4 overflow-y-auto md:sticky md:w-80",
-          )}
-        >
+        <div className="h-fit w-full shrink-0 space-y-4 overflow-y-auto md:w-80">
           <div className="space-y-2">
             <div className="w-fit">
               <p

--- a/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
@@ -17,7 +17,6 @@ import { validateAvailabilityData } from "@/features/event/availability/validate
 import TimeZoneSelector from "@/features/event/components/selectors/timezone";
 import { ScheduleGrid } from "@/features/event/grid";
 import HeaderSpacer from "@/features/header/components/header-spacer";
-import { useHeaderSize } from "@/features/header/context";
 import {
   ConfirmationDialog,
   RateLimitBanner,
@@ -28,7 +27,6 @@ import { clientPost } from "@/lib/utils/api/client-fetch";
 import { ROUTES } from "@/lib/utils/api/endpoints";
 import { ApiErrorResponse } from "@/lib/utils/api/fetch-wrapper";
 import { SelfAvailability } from "@/lib/utils/api/types";
-import { cn } from "@/lib/utils/classname";
 import { timeslotToISOString } from "@/lib/utils/date-time-format";
 
 export default function ClientPage({
@@ -45,9 +43,6 @@ export default function ClientPage({
   initialData: SelfAvailability | null;
 }) {
   const router = useRouter();
-
-  // HEADER SIZE CONTEXT
-  const { topMarginClass } = useHeaderSize();
 
   // AVAILABILITY STATE
   const { state, setDisplayName, setTimeZone, toggleSlot } = useAvailability(

--- a/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/painting/page-client.tsx
@@ -246,7 +246,7 @@ export default function ClientPage({
   );
 
   return (
-    <div className="flex flex-col space-y-4 pl-6 pr-6">
+    <div className="flex flex-col space-y-4 pl-6 pr-6 md:h-screen">
       <HeaderSpacer />
 
       {/* Rate Limit Error */}
@@ -264,7 +264,7 @@ export default function ClientPage({
       </div>
 
       {/* Main Content */}
-      <div className="mb-12 flex h-fit flex-col gap-4 md:mb-0 md:flex-row">
+      <div className="mb-12 flex min-h-0 flex-1 flex-col gap-4 md:mb-0 md:flex-row">
         {/* Left Panel */}
         <div
           className={cn(

--- a/frontend/src/features/event/grid/grid.tsx
+++ b/frontend/src/features/event/grid/grid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { AnimatePresence, motion } from "framer-motion";
 import { TriangleAlertIcon } from "lucide-react";
@@ -94,6 +94,23 @@ export default function ScheduleGrid({
   const hasPrevPage = currentPage > 0;
   const hasNextPage = currentPage < totalPages - 1;
 
+  // Check if the scrollbar is present to pass to the header
+  const [scrollbarPresent, setScrollbarPresent] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const checkScrollbar = () =>
+      // Include mobile check because it will report true even if the scrollbar is hidden
+      setScrollbarPresent(el.scrollHeight > el.clientHeight && !isMobile);
+    const resizeObserver = new ResizeObserver(checkScrollbar);
+    resizeObserver.observe(el);
+    checkScrollbar();
+
+    return () => resizeObserver.disconnect();
+  });
+
   if (error) return <GridError message={error} />;
 
   return (
@@ -108,6 +125,7 @@ export default function ScheduleGrid({
         visibleDays={visibleDays}
         currentPage={currentPage}
         totalPages={totalPages}
+        scrollbarPresent={scrollbarPresent}
         isWeekdayEvent={isWeekdayEvent}
         onPrevPage={() => paginate(-1)}
         onNextPage={() => paginate(1)}
@@ -115,6 +133,7 @@ export default function ScheduleGrid({
       />
 
       <div
+        ref={scrollRef}
         className={cn(
           "relative flex-grow select-none overflow-x-hidden pt-2",
           !isMobile ? "overflow-y-auto" : "overflow-y-hidden",

--- a/frontend/src/features/event/grid/grid.tsx
+++ b/frontend/src/features/event/grid/grid.tsx
@@ -117,7 +117,7 @@ export default function ScheduleGrid({
       <div
         className={cn(
           "relative flex-grow select-none overflow-x-hidden pb-1 pt-2",
-          mode === "preview" ? "overflow-y-auto" : "overflow-y-hidden",
+          !isMobile ? "overflow-y-auto" : "overflow-y-hidden",
         )}
       >
         <div className="z-5 pointer-events-none absolute left-0 top-2 flex w-full flex-col gap-4">

--- a/frontend/src/features/event/grid/grid.tsx
+++ b/frontend/src/features/event/grid/grid.tsx
@@ -116,8 +116,9 @@ export default function ScheduleGrid({
 
       <div
         className={cn(
-          "relative flex-grow select-none overflow-x-hidden pb-1 pt-2",
+          "relative flex-grow select-none overflow-x-hidden pt-2",
           !isMobile ? "overflow-y-auto" : "overflow-y-hidden",
+          mode === "preview" ? "pb-1" : "pb-6",
         )}
       >
         <div className="z-5 pointer-events-none absolute left-0 top-2 flex w-full flex-col gap-4">

--- a/frontend/src/features/event/grid/schedule-header.tsx
+++ b/frontend/src/features/event/grid/schedule-header.tsx
@@ -16,6 +16,7 @@ interface ScheduleHeaderProps {
   visibleDays: { dayKey: string; dayDisplay: string }[];
   currentPage: number;
   totalPages: number;
+  scrollbarPresent?: boolean;
   isWeekdayEvent?: boolean;
   onPrevPage: () => void;
   onNextPage: () => void;
@@ -42,6 +43,7 @@ export default function ScheduleHeader({
   visibleDays,
   currentPage,
   totalPages,
+  scrollbarPresent = false,
   isWeekdayEvent = false,
   onPrevPage,
   onNextPage,
@@ -52,7 +54,8 @@ export default function ScheduleHeader({
   return (
     <div
       className={cn(
-        preview ? "bg-panel top-0 pr-4" : cn(topMarginClass, "bg-background"),
+        preview ? "bg-panel top-0" : cn(topMarginClass, "bg-background"),
+        scrollbarPresent && "pr-4",
         "sticky z-10 col-span-2 grid h-[50px] w-full items-center justify-center",
       )}
       style={{


### PR DESCRIPTION
This PR changes the grid to be scrollable in all instances on desktop. This removes the need for a sticky header and sidebar on the painting and results pages, since the page itself no longer scrolls.