### PR TITLE
Add distinction for best times

### DIFF
--- a/frontend/src/features/event/grid/grid.tsx
+++ b/frontend/src/features/event/grid/grid.tsx
@@ -14,6 +14,7 @@ import TimeColumn from "@/features/event/grid/time-column";
 import InteractiveTimeBlock from "@/features/event/grid/timeblocks/interactive";
 import PreviewTimeBlock from "@/features/event/grid/timeblocks/preview";
 import ResultsTimeBlock from "@/features/event/grid/timeblocks/results";
+import { getHighestMatchCount } from "@/features/event/results/lib/utils";
 import useCheckMobile from "@/lib/hooks/use-check-mobile";
 import { cn } from "@/lib/utils/classname";
 
@@ -171,6 +172,7 @@ export default function ScheduleGrid({
                       hoveredSlot={hoveredSlot}
                       availabilities={availabilities}
                       numParticipants={numParticipants}
+                      highestMatchCount={getHighestMatchCount(availabilities)}
                       onHoverSlot={setHoveredSlot}
                     />
                   );

--- a/frontend/src/features/event/grid/time-slot.tsx
+++ b/frontend/src/features/event/grid/time-slot.tsx
@@ -16,6 +16,7 @@ interface TimeSlotProps {
   gridRow: number;
 
   icon?: React.ReactNode;
+  number?: number;
 
   cellClasses?: string;
 
@@ -74,7 +75,7 @@ function TimeSlot({
       {...eventHandlers}
     >
       {icon && (
-        <div className="flex h-full items-center justify-center">{icon}</div>
+        <div className="flex h-full items-center justify-end pr-1">{icon}</div>
       )}
     </div>
   );

--- a/frontend/src/features/event/grid/time-slot.tsx
+++ b/frontend/src/features/event/grid/time-slot.tsx
@@ -15,6 +15,8 @@ interface TimeSlotProps {
   gridColumn: number;
   gridRow: number;
 
+  icon?: React.ReactNode;
+
   cellClasses?: string;
 
   // Event handlers
@@ -31,9 +33,22 @@ function TimeSlot({
   dynamicStyle: style,
   gridColumn,
   gridRow,
+  icon,
   cellClasses = "",
   ...eventHandlers
 }: TimeSlotProps) {
+  if (icon) {
+    icon = React.cloneElement(
+      icon as React.ReactElement<{ className: string }>,
+      {
+        className: cn(
+          (icon as React.ReactElement<{ className: string }>).props.className,
+          "h-4 w-4",
+        ),
+      },
+    );
+  }
+
   return (
     <div
       data-slot-iso={slotIso}
@@ -57,7 +72,11 @@ function TimeSlot({
         ...style,
       }}
       {...eventHandlers}
-    />
+    >
+      {icon && (
+        <div className="flex h-full items-center justify-center">{icon}</div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/features/event/grid/time-slot.tsx
+++ b/frontend/src/features/event/grid/time-slot.tsx
@@ -16,7 +16,6 @@ interface TimeSlotProps {
   gridRow: number;
 
   icon?: React.ReactNode;
-  number?: number;
 
   cellClasses?: string;
 

--- a/frontend/src/features/event/grid/time-slot.tsx
+++ b/frontend/src/features/event/grid/time-slot.tsx
@@ -45,7 +45,7 @@ function TimeSlot({
         cellClasses,
         "select-none",
         isHovered &&
-          "z-5 scale-y-130 scale-x-110 rounded-full border-none shadow-xl ring-1 md:scale-x-105",
+          "z-5 -inset-1 h-[calc(100%+0.5rem)] w-[calc(100%+0.5rem)] rounded-full border-none shadow-xl ring-1",
       )}
       style={{
         gridColumn,

--- a/frontend/src/features/event/grid/time-slot.tsx
+++ b/frontend/src/features/event/grid/time-slot.tsx
@@ -15,7 +15,7 @@ interface TimeSlotProps {
   gridColumn: number;
   gridRow: number;
 
-  icon?: React.ReactNode;
+  icon?: React.ReactElement;
 
   cellClasses?: string;
 

--- a/frontend/src/features/event/grid/time-slot.tsx
+++ b/frontend/src/features/event/grid/time-slot.tsx
@@ -45,7 +45,7 @@ function TimeSlot({
         cellClasses,
         "select-none",
         isHovered &&
-          "z-5 -inset-1 h-[calc(100%+0.5rem)] w-[calc(100%+0.5rem)] rounded-full border-none shadow-xl ring-1",
+          "z-5 -inset-1 h-[calc(100%+0.5rem)] w-[calc(100%+0.5rem)] rounded-full border-none shadow-xl ring-2",
       )}
       style={{
         gridColumn,

--- a/frontend/src/features/event/grid/time-slot.tsx
+++ b/frontend/src/features/event/grid/time-slot.tsx
@@ -45,7 +45,7 @@ function TimeSlot({
         cellClasses,
         "select-none",
         isHovered &&
-          "z-5 -inset-1 h-[calc(100%+0.5rem)] w-[calc(100%+0.5rem)] rounded-full border-none shadow-xl ring-2",
+          "z-5 -inset-x-1 -inset-y-0.5 h-[calc(100%+0.25rem)] w-[calc(100%+0.5rem)] rounded-full border-none shadow-xl ring-2",
       )}
       style={{
         gridColumn,

--- a/frontend/src/features/event/grid/timeblocks/props.ts
+++ b/frontend/src/features/event/grid/timeblocks/props.ts
@@ -37,5 +37,6 @@ export type ResultsTimeBlockProps = CommonBlockProps & {
   hoveredSlot: string | null | undefined;
   availabilities: ResultsAvailabilityMap;
   numParticipants: number;
+  highestMatchCount: number;
   onHoverSlot?: (iso: string | null) => void;
 };

--- a/frontend/src/features/event/grid/timeblocks/results.tsx
+++ b/frontend/src/features/event/grid/timeblocks/results.tsx
@@ -1,3 +1,5 @@
+import { SparklesIcon } from "lucide-react";
+
 import TimeSlot from "@/features/event/grid/time-slot";
 import BaseTimeBlock from "@/features/event/grid/timeblocks/base";
 import { ResultsTimeBlockProps } from "@/features/event/grid/timeblocks/props";
@@ -41,6 +43,14 @@ export default function ResultsTimeBlock({
           "bg-[color-mix(in_srgb,var(--color-accent)_var(--opacity-percent),var(--color-background))]",
         );
 
+        // icon
+        const iconColorClass =
+          opacityPercent > 50 ? "text-white" : "text-foreground";
+        const icon =
+          matchCount === numParticipants && numParticipants > 1 ? (
+            <SparklesIcon className={iconColorClass} />
+          ) : undefined;
+
         return (
           <TimeSlot
             key={iso}
@@ -49,6 +59,7 @@ export default function ResultsTimeBlock({
             isHovered={isHovered}
             gridColumn={gridColumn}
             gridRow={gridRow}
+            icon={icon}
             onPointerEnter={() => {
               onHoverSlot?.(iso);
             }}

--- a/frontend/src/features/event/grid/timeblocks/results.tsx
+++ b/frontend/src/features/event/grid/timeblocks/results.tsx
@@ -1,4 +1,4 @@
-import { SparklesIcon } from "lucide-react";
+import { SparklesIcon, ThumbsUpIcon } from "lucide-react";
 
 import TimeSlot from "@/features/event/grid/time-slot";
 import BaseTimeBlock from "@/features/event/grid/timeblocks/base";
@@ -10,6 +10,7 @@ export default function ResultsTimeBlock({
   numVisibleDays,
   availabilities,
   numParticipants,
+  highestMatchCount,
   hoveredSlot,
   onHoverSlot,
   hasNext = false,
@@ -47,8 +48,12 @@ export default function ResultsTimeBlock({
         const iconColorClass =
           opacityPercent > 50 ? "text-white" : "text-foreground";
         const icon =
-          matchCount === numParticipants && numParticipants > 1 ? (
-            <SparklesIcon className={iconColorClass} />
+          highestMatchCount > 1 && matchCount === highestMatchCount ? (
+            highestMatchCount === numParticipants ? (
+              <SparklesIcon className={iconColorClass} />
+            ) : (
+              <ThumbsUpIcon className={iconColorClass} />
+            )
           ) : undefined;
 
         return (

--- a/frontend/src/features/event/grid/timeblocks/results.tsx
+++ b/frontend/src/features/event/grid/timeblocks/results.tsx
@@ -1,4 +1,4 @@
-import { SparklesIcon, ThumbsUpIcon } from "lucide-react";
+import { CircleSmallIcon, ThumbsUpIcon } from "lucide-react";
 
 import TimeSlot from "@/features/event/grid/time-slot";
 import BaseTimeBlock from "@/features/event/grid/timeblocks/base";
@@ -50,9 +50,9 @@ export default function ResultsTimeBlock({
         const icon =
           highestMatchCount > 1 && matchCount === highestMatchCount ? (
             highestMatchCount === numParticipants ? (
-              <SparklesIcon className={iconColorClass} />
-            ) : (
               <ThumbsUpIcon className={iconColorClass} />
+            ) : (
+              <CircleSmallIcon className={iconColorClass} />
             )
           ) : undefined;
 

--- a/frontend/src/features/event/results/banners.tsx
+++ b/frontend/src/features/event/results/banners.tsx
@@ -42,7 +42,7 @@ export function getResultBanners(
     }
     return (
       <Banner type="info" subtitle="Oh dear :(" showPing>
-        <p>{MESSAGES.INFO_NO_IDEAL_TIMES}</p>
+        <p>{MESSAGES.INFO_NO_IDEAL_TIMES_BANNER}</p>
       </Banner>
     );
   } else if (participated && participants.length === 1) {

--- a/frontend/src/features/event/results/banners.tsx
+++ b/frontend/src/features/event/results/banners.tsx
@@ -1,5 +1,8 @@
 import { ResultsAvailabilityMap } from "@/core/availability/types";
-import { hasMutualAvailability } from "@/features/event/results/lib/utils";
+import {
+  getHighestMatchCount,
+  hasMutualAvailability,
+} from "@/features/event/results/lib/utils";
 import { Banner } from "@/features/system-feedback/banner/base";
 import { MESSAGES } from "@/lib/messages";
 
@@ -30,9 +33,16 @@ export function getResultBanners(
       </Banner>
     );
   } else if (!hasMutualAvailability(availabilities, participants)) {
+    if (getHighestMatchCount(availabilities) <= 1) {
+      return (
+        <Banner type="info" subtitle="Yikes..." showPing>
+          <p>{MESSAGES.INFO_NO_MUTUAL_AVAILABILITY}</p>
+        </Banner>
+      );
+    }
     return (
       <Banner type="info" subtitle="Oh dear :(" showPing>
-        <p>{MESSAGES.INFO_NO_MUTUAL_AVAILABILITY}</p>
+        <p>{MESSAGES.INFO_NO_IDEAL_TIMES}</p>
       </Banner>
     );
   } else if (participated && participants.length === 1) {

--- a/frontend/src/features/event/results/lib/utils.ts
+++ b/frontend/src/features/event/results/lib/utils.ts
@@ -51,3 +51,19 @@ export function findConsensusAndConflicts(
 
   return { allAvailableSlots, noOneAvailableSlots };
 }
+
+/**
+ * Finds the highest number of participants available for any single timeslot.
+ * 
+ * @returns The maximum count of participants available in any timeslot.
+ */
+export function getHighestMatchCount(availabilities: ResultsAvailabilityMap): number {
+  let highestCount = 0;
+  for (const slot in availabilities) {
+    const count = availabilities[slot].length;
+    if (count > highestCount) {
+      highestCount = count;
+    }
+  }
+  return highestCount;
+}

--- a/frontend/src/lib/messages.ts
+++ b/frontend/src/lib/messages.ts
@@ -58,5 +58,6 @@ export const MESSAGES = {
   INFO_ADD_AVAILABILITY: "Add your availability by clicking the button above.",
   INFO_ADD_AVAILABILITY_MOBILE: "Add your availability by clicking the button below.",
   INFO_COPY_SHARE_LINK: "Copy and share the link so others can join!",
-  INFO_NO_MUTUAL_AVAILABILITY: "There is no time where everyone is available.",
+  INFO_NO_MUTUAL_AVAILABILITY: "There are no times with more than 1 person available. The plans are NOT making it out of the group chat...",
+  INFO_NO_IDEAL_TIMES: "There is no time where everyone is available. Times with an indicator are the best options.",
 };

--- a/frontend/src/lib/messages.ts
+++ b/frontend/src/lib/messages.ts
@@ -59,5 +59,6 @@ export const MESSAGES = {
   INFO_ADD_AVAILABILITY_MOBILE: "Add your availability by clicking the button below.",
   INFO_COPY_SHARE_LINK: "Copy and share the link so others can join!",
   INFO_NO_MUTUAL_AVAILABILITY: "There are no times with more than 1 person available. The plans are NOT making it out of the group chat...",
-  INFO_NO_IDEAL_TIMES: "There is no time where everyone is available. Times with an indicator are the best options.",
+  INFO_NO_IDEAL_TIMES: "There are no times where everyone is available.",
+  INFO_NO_IDEAL_TIMES_BANNER: "There are no times where everyone is available. Times with an indicator are the best options.",
 };


### PR DESCRIPTION
This PR adds icons to the results grid for the best times, along with a few adjustments.

### Grid Icons
On time slots with everyone available, a "thumbs up" icon is displayed. On the best time slots when there are no ideal times, a "small circle" icon is displayed. The latter is intended to just draw attention to the time slot, and the banner adjustment also helps with this.

If the best time slots only have 1 person available, no icon will be shown.

These rules also apply when filtering attendees.

### Time Slot Hover Size Adjustment
Before, time slots were scaled relative to their size, resulting in extremely large time slots that would even get cut off when a page only has a few days. This is now a flat size increase, so it's consistent between grid column sizes.

This also fixes an issue where the time chips would cover the hovered time slot.

### Banner Adjustments
There are now two different banners in the "no mutual availabilities" case. If there are no times with more than 1 person available, that will be noted. Otherwise, the banner will tell the user to look for time slots with the icon indicator.