### PR TITLE
New theme picker

### DIFF
--- a/frontend/src/components/kebab-menu.tsx
+++ b/frontend/src/components/kebab-menu.tsx
@@ -21,12 +21,14 @@ export default function KebabMenu({
   open: controlledOpen,
   onOpenChange,
   nested = false,
+  closeOnClick = true,
 }: {
   children: React.ReactNode;
   trigger?: React.ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   nested?: boolean;
+  closeOnClick?: boolean;
 }) {
   const id = useId();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -112,10 +114,11 @@ export default function KebabMenu({
             onClick={(e) => {
               const target = e.target as HTMLElement;
               if (
-                target.closest("button") ||
-                target.closest("a") ||
-                target.closest('[role="button"]') ||
-                target.closest('[role="menuitem"]')
+                (target.closest("button") ||
+                  target.closest("a") ||
+                  target.closest('[role="button"]') ||
+                  target.closest('[role="menuitem"]')) &&
+                closeOnClick
               ) {
                 handleOpenChange(false);
               }

--- a/frontend/src/components/kebab-menu.tsx
+++ b/frontend/src/components/kebab-menu.tsx
@@ -15,11 +15,14 @@ const morphTransition: Transition = {
   mass: 0.8,
 };
 
+export type AnchorPoint = "top-left" | "top-center" | "top-right";
+
 export default function KebabMenu({
   children,
   trigger,
   open: controlledOpen,
   onOpenChange,
+  anchorPoint = "top-right",
   nested = false,
   closeOnClick = true,
 }: {
@@ -27,6 +30,7 @@ export default function KebabMenu({
   trigger?: React.ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  anchorPoint?: AnchorPoint;
   nested?: boolean;
   closeOnClick?: boolean;
 }) {
@@ -85,7 +89,12 @@ export default function KebabMenu({
             key="trigger"
             layoutId={"popover-morph-" + id}
             transition={morphTransition}
-            className="absolute right-0 top-0 z-10 inline-block cursor-pointer rounded-full"
+            className={cn(
+              "absolute top-0 z-10 inline-block cursor-pointer rounded-full",
+              anchorPoint === "top-right" && "right-0",
+              anchorPoint === "top-left" && "left-0",
+              anchorPoint === "top-center" && "left-1/2 -translate-x-1/2",
+            )}
             aria-haspopup="menu"
             aria-expanded={open}
             onClick={() => handleOpenChange(true)}
@@ -106,8 +115,12 @@ export default function KebabMenu({
             layoutId={"popover-morph-" + id}
             transition={morphTransition}
             className={cn(
-              "absolute right-2 top-1 z-[100]",
-              "flex min-w-[200px] origin-top-right flex-col gap-2",
+              "absolute top-1 z-[100]",
+              anchorPoint === "top-right" && "right-2 origin-top-right",
+              anchorPoint === "top-left" && "left-2 origin-top-left",
+              anchorPoint === "top-center" &&
+                "left-1/2 origin-top -translate-x-1/2",
+              "flex min-w-[200px] flex-col gap-2",
               "frosted-glass overflow-hidden rounded-3xl p-4 shadow-lg",
               nested && "scale-110",
             )}

--- a/frontend/src/components/segmented-control.tsx
+++ b/frontend/src/components/segmented-control.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import { cn } from "@/lib/utils/classname";
 
 type SegmentedControlProps<T extends string> = {
-  options: { label: React.ReactNode; value: T }[];
+  options: { label: React.ReactNode; value: T; ariaLabel?: string }[];
   value: T;
   onChange: (value: T) => void;
   className?: string;
@@ -53,6 +53,7 @@ export default function SegmentedControl<T extends string>({
             key={option.value}
             type="button"
             onClick={() => onChange(option.value)}
+            aria-label={option.ariaLabel}
             className={cn(
               "z-10 flex w-full items-center justify-center rounded-full py-2 text-sm font-medium transition-colors duration-300 focus:outline-none",
               isSelected

--- a/frontend/src/features/header/components/header.tsx
+++ b/frontend/src/features/header/components/header.tsx
@@ -8,7 +8,7 @@ import AccountButton from "@/features/header/components/account-button";
 import DashboardButton from "@/features/header/components/dashboard-button";
 import LogoArea from "@/features/header/components/logo-area";
 import NewEventButton from "@/features/header/components/new-event-button";
-import ThemeToggle from "@/features/header/components/theme-toggle";
+import ThemePicker from "@/features/header/components/theme-picker";
 import { useHeaderSize } from "@/features/header/context";
 import useCheckMobile from "@/lib/hooks/use-check-mobile";
 import { cn } from "@/lib/utils/classname";
@@ -107,7 +107,7 @@ export default function Header() {
           />
 
           <NewEventButton />
-          <ThemeToggle />
+          <ThemePicker />
           <DashboardButton />
           <AccountButton />
 

--- a/frontend/src/features/header/components/theme-picker.tsx
+++ b/frontend/src/features/header/components/theme-picker.tsx
@@ -9,7 +9,7 @@ import EmptyButton from "@/features/button/components/empty";
 import ShrinkingHeaderButton from "@/features/header/components/shrinking-header-button";
 import { useHeaderSize } from "@/features/header/context";
 
-export default function ThemeToggle() {
+export default function ThemePicker() {
   const { activeMenu, setActiveMenu } = useHeaderSize();
   const { theme = "system", setTheme } = useTheme();
 

--- a/frontend/src/features/header/components/theme-picker.tsx
+++ b/frontend/src/features/header/components/theme-picker.tsx
@@ -37,9 +37,13 @@ export default function ThemePicker() {
         <div className="text-center font-bold">Theme</div>
         <SegmentedControl
           options={[
-            { value: "system", label: <MonitorIcon /> },
-            { value: "light", label: <SunIcon /> },
-            { value: "dark", label: <MoonIcon /> },
+            {
+              value: "system",
+              label: <MonitorIcon />,
+              ariaLabel: "Match System Theme",
+            },
+            { value: "light", label: <SunIcon />, ariaLabel: "Light Theme" },
+            { value: "dark", label: <MoonIcon />, ariaLabel: "Dark Theme" },
           ]}
           value={theme}
           onChange={setTheme}

--- a/frontend/src/features/header/components/theme-toggle.tsx
+++ b/frontend/src/features/header/components/theme-toggle.tsx
@@ -30,6 +30,7 @@ export default function ThemeToggle() {
             icon={<SunMoonIcon />}
           />
         }
+        closeOnClick={false}
       >
         <SegmentedControl
           options={[

--- a/frontend/src/features/header/components/theme-toggle.tsx
+++ b/frontend/src/features/header/components/theme-toggle.tsx
@@ -29,6 +29,7 @@ export default function ThemeToggle() {
           <EmptyButton
             buttonStyle="frosted glass inset"
             icon={<SunMoonIcon />}
+            aria-label="Choose Site Theme"
           />
         }
         closeOnClick={false}

--- a/frontend/src/features/header/components/theme-toggle.tsx
+++ b/frontend/src/features/header/components/theme-toggle.tsx
@@ -33,6 +33,7 @@ export default function ThemeToggle() {
         }
         closeOnClick={false}
       >
+        <div className="text-center font-bold">Theme</div>
         <SegmentedControl
           options={[
             { value: "system", label: <MonitorIcon /> },
@@ -43,6 +44,13 @@ export default function ThemeToggle() {
           onChange={setTheme}
           className="frosted-glass-inset"
         />
+        <div className="text-center text-sm opacity-75">
+          {theme === "system"
+            ? "Match System"
+            : theme === "light"
+              ? "Light"
+              : "Dark"}
+        </div>
       </KebabMenu>
     </ShrinkingHeaderButton>
   );

--- a/frontend/src/features/header/components/theme-toggle.tsx
+++ b/frontend/src/features/header/components/theme-toggle.tsx
@@ -1,28 +1,40 @@
 "use client";
 
-import { MoonIcon, SunIcon } from "lucide-react";
+import { MonitorIcon, MoonIcon, SunIcon, SunMoonIcon } from "lucide-react";
 import { useTheme } from "next-themes";
 
-import ActionButton from "@/features/button/components/action";
+import KebabMenu from "@/components/kebab-menu";
+import SegmentedControl from "@/components/segmented-control";
+import EmptyButton from "@/features/button/components/empty";
 import ShrinkingHeaderButton from "@/features/header/components/shrinking-header-button";
 
 export default function ThemeToggle() {
-  const { setTheme, resolvedTheme } = useTheme();
-
-  const toggleTheme = () => {
-    setTheme(resolvedTheme === "dark" ? "light" : "dark");
-  };
+  const { theme = "system", setTheme } = useTheme();
 
   return (
     <ShrinkingHeaderButton
       buttonStyle="frosted glass inset"
-      icon={resolvedTheme === "dark" ? <MoonIcon /> : <SunIcon />}
+      icon={<SunMoonIcon />}
     >
-      <ActionButton
-        buttonStyle="frosted glass inset"
-        icon={resolvedTheme === "dark" ? <MoonIcon /> : <SunIcon />}
-        onClick={toggleTheme}
-      />
+      <KebabMenu
+        trigger={
+          <EmptyButton
+            buttonStyle="frosted glass inset"
+            icon={<SunMoonIcon />}
+          />
+        }
+      >
+        <SegmentedControl
+          options={[
+            { value: "system", label: <MonitorIcon /> },
+            { value: "light", label: <SunIcon /> },
+            { value: "dark", label: <MoonIcon /> },
+          ]}
+          value={theme}
+          onChange={setTheme}
+          className="frosted-glass-inset"
+        />
+      </KebabMenu>
     </ShrinkingHeaderButton>
   );
 }

--- a/frontend/src/features/header/components/theme-toggle.tsx
+++ b/frontend/src/features/header/components/theme-toggle.tsx
@@ -7,9 +7,13 @@ import KebabMenu from "@/components/kebab-menu";
 import SegmentedControl from "@/components/segmented-control";
 import EmptyButton from "@/features/button/components/empty";
 import ShrinkingHeaderButton from "@/features/header/components/shrinking-header-button";
+import { useHeaderSize } from "@/features/header/context";
 
 export default function ThemeToggle() {
+  const { activeMenu, setActiveMenu } = useHeaderSize();
   const { theme = "system", setTheme } = useTheme();
+
+  const isMenuOpen = activeMenu === "theme";
 
   return (
     <ShrinkingHeaderButton
@@ -17,6 +21,9 @@ export default function ThemeToggle() {
       icon={<SunMoonIcon />}
     >
       <KebabMenu
+        nested
+        open={isMenuOpen}
+        onOpenChange={(isOpen) => setActiveMenu(isOpen ? "theme" : null)}
         trigger={
           <EmptyButton
             buttonStyle="frosted glass inset"

--- a/frontend/src/features/header/components/theme-toggle.tsx
+++ b/frontend/src/features/header/components/theme-toggle.tsx
@@ -24,6 +24,7 @@ export default function ThemeToggle() {
         nested
         open={isMenuOpen}
         onOpenChange={(isOpen) => setActiveMenu(isOpen ? "theme" : null)}
+        anchorPoint="top-center"
         trigger={
           <EmptyButton
             buttonStyle="frosted glass inset"


### PR DESCRIPTION
This PR introduces a new theme picker in the header.

### New Theme Picker
Clicking the theme picker button no longer toggles between dark and light mode. Instead, it opens a kebab menu with a segmented control to pick a theme.

Included in this is a new option for themes, that being "Match System". Lucky for us, this is built-in functionality to Next themes.

### Kebab Menu Adjustments
A few new optional props were added to the kebab menu to support this new functionality:
- `closeOnClick` defaults to `true`, but setting it to false makes the kebab menu stay open even after picking an option.
- `anchorPoint` defaults to `"top-right"`, but you can choose between `"top-center"` and `"top-left"` as well to make the kebab menu be anchored at different points.