### PR TITLE
Update self event removal

### DIFF
--- a/frontend/src/features/event/results/attendee-panel/panel-header.tsx
+++ b/frontend/src/features/event/results/attendee-panel/panel-header.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, EraserIcon, LogOutIcon, Undo2Icon } from "lucide-react";
+import { CheckIcon, DoorOpenIcon, EraserIcon, Undo2Icon } from "lucide-react";
 
 import ActionButton from "@/features/button/components/action";
 import { useResultsContext } from "@/features/event/results/context";
@@ -125,7 +125,7 @@ export default function PanelHeader({
           {showSelfRemove && (
             <ActionButton
               buttonStyle="semi-transparent"
-              icon={<LogOutIcon />}
+              icon={<DoorOpenIcon />}
               onClick={() => {
                 promptRemove(currentUser);
               }}

--- a/frontend/src/features/event/results/attendee-panel/panel-header.tsx
+++ b/frontend/src/features/event/results/attendee-panel/panel-header.tsx
@@ -129,7 +129,7 @@ export default function PanelHeader({
               onClick={() => {
                 promptRemove(currentUser);
               }}
-              aria-label="Remove Self from Event"
+              aria-label="Leave Event"
               className="hover:bg-error/25 hover:text-error active:bg-error/40 shrink-0"
             />
           )}

--- a/frontend/src/features/event/results/attendee-panel/panel.tsx
+++ b/frontend/src/features/event/results/attendee-panel/panel.tsx
@@ -61,7 +61,7 @@ export default function AttendeesPanel() {
           personToRemove === currentUser ? "Leave Event" : "Remove Participant"
         }
         description={
-          personToRemove == currentUser ? (
+          personToRemove === currentUser ? (
             "Are you sure you want to leave this event?"
           ) : (
             <span>

--- a/frontend/src/features/event/results/attendee-panel/panel.tsx
+++ b/frontend/src/features/event/results/attendee-panel/panel.tsx
@@ -58,13 +58,11 @@ export default function AttendeesPanel() {
         type="delete"
         autoClose={true}
         title={
-          personToRemove === currentUser
-            ? "Remove Yourself"
-            : "Remove Participant"
+          personToRemove === currentUser ? "Leave Event" : "Remove Participant"
         }
         description={
           personToRemove == currentUser ? (
-            "Are you sure you want to remove yourself from this event?"
+            "Are you sure you want to leave this event?"
           ) : (
             <span>
               Are you sure you want to remove{" "}

--- a/frontend/src/features/event/results/drawer.tsx
+++ b/frontend/src/features/event/results/drawer.tsx
@@ -131,13 +131,11 @@ export default function ResultsDrawer({
         type="delete"
         autoClose={true}
         title={
-          personToRemove === currentUser
-            ? "Remove Yourself"
-            : "Remove Participant"
+          personToRemove === currentUser ? "Leave Event" : "Remove Participant"
         }
         description={
           personToRemove == currentUser ? (
-            "Are you sure you want to remove yourself from this event?"
+            "Are you sure you want to leave this event?"
           ) : (
             <span>
               Are you sure you want to remove{" "}


### PR DESCRIPTION
This PR makes some slight changes to the self event removal.

### New Icon
The conflicting icon (with sign out) has been replaced with the open door icon.

### Updated Wording
To match this icon, the wording was changed from "remove yourself" to "leave event".