### PR TITLE
Add isort dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ django-environ==0.12.0
 django-ses==4.4.0
 djangorestframework==3.16.0
 gunicorn==23.0.0
+isort==8.0.1
 jmespath==1.0.1
 kombu==5.5.4
 packaging==25.0


### PR DESCRIPTION
I'm not entirely sure what changed, but isort doesn't work anymore unless it's installed into the Python environment you're using.

This just adds the package to `requirements.txt`.