### PR TITLE
Tooltips

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-select": "^2.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-toast": "^1.2.15",
+        "@radix-ui/react-tooltip": "^1.2.9",
         "@vercel/analytics": "^2.0.1",
         "clsx": "^2.1.1",
         "date-fns-tz": "^3.2.0",
@@ -3016,6 +3017,414 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.9.tgz",
+      "integrity": "sha512-u6F9MmTtBSLkiXNVDrtB/yPCZarM9smNswC24YYLV/M+bth6J3Gs3vlJezEoFwKZvPvxhCpUYdUnOsNG/0XOlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-visually-hidden": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.9.tgz",
+      "integrity": "sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz",
+      "integrity": "sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.0.tgz",
+      "integrity": "sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.11.tgz",
+      "integrity": "sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.5.tgz",
+      "integrity": "sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-toast": "^1.2.15",
+    "@radix-ui/react-tooltip": "^1.2.9",
     "@vercel/analytics": "^2.0.1",
     "clsx": "^2.1.1",
     "date-fns-tz": "^3.2.0",

--- a/frontend/src/components/info-point.tsx
+++ b/frontend/src/components/info-point.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { CircleQuestionMarkIcon } from "lucide-react";
 
 import { FloatingDrawer } from "@/features/drawer";
-import Tooltip from "@/features/system-feedback/tooltip/base";
+import Tooltip, { TooltipSide } from "@/features/system-feedback/tooltip/base";
 
 export default function InfoPoint({
   tooltipSide = "top",
@@ -13,7 +13,7 @@ export default function InfoPoint({
   drawerContent,
   className,
 }: {
-  tooltipSide?: "top" | "bottom";
+  tooltipSide?: TooltipSide;
   drawerTitle: string;
   drawerDescription: string;
   tooltipContent: React.ReactNode;

--- a/frontend/src/components/info-point.tsx
+++ b/frontend/src/components/info-point.tsx
@@ -1,0 +1,19 @@
+import { CircleQuestionMarkIcon } from "lucide-react";
+
+import Tooltip from "@/features/system-feedback/tooltip/base";
+
+export default function InfoPoint({
+  tooltipSide = "top",
+  content,
+  className,
+}: {
+  tooltipSide?: "top" | "bottom";
+  content: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <Tooltip side={tooltipSide} content={content}>
+      <CircleQuestionMarkIcon className={className} />
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/info-point.tsx
+++ b/frontend/src/components/info-point.tsx
@@ -7,15 +7,17 @@ import Tooltip from "@/features/system-feedback/tooltip/base";
 
 export default function InfoPoint({
   tooltipSide = "top",
-  title,
-  description,
-  content,
+  drawerTitle,
+  drawerDescription,
+  tooltipContent,
+  drawerContent,
   className,
 }: {
   tooltipSide?: "top" | "bottom";
-  title: string;
-  description: string;
-  content: React.ReactNode;
+  drawerTitle: string;
+  drawerDescription: string;
+  tooltipContent: React.ReactNode;
+  drawerContent: React.ReactNode;
   className?: string;
 }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -31,7 +33,7 @@ export default function InfoPoint({
 
   return (
     <>
-      <Tooltip side={tooltipSide} content={content}>
+      <Tooltip side={tooltipSide} content={tooltipContent}>
         <CircleQuestionMarkIcon
           className={className}
           onClick={() => setDrawerOpen(isTouchDevice)}
@@ -40,10 +42,10 @@ export default function InfoPoint({
       <FloatingDrawer
         open={drawerOpen}
         onOpenChange={setDrawerOpen}
-        title={title}
-        description={description}
+        title={drawerTitle}
+        description={drawerDescription}
       >
-        {content}
+        {drawerContent}
       </FloatingDrawer>
     </>
   );

--- a/frontend/src/components/info-point.tsx
+++ b/frontend/src/components/info-point.tsx
@@ -15,11 +15,11 @@ type InfoPointProps = {
   /**
    * The title displayed on the drawer when tapping the info point on mobile.
    */
-  drawerTitle: string;
+  title: string;
   /**
-   * Hidden description for the drawer shown on mobile, to aid with accessibility.
+   * Hidden description for use with screen readers.
    */
-  drawerDescription: string;
+  description: string;
   /**
    * The content to be displayed on desktop when hovering the info point.
    */
@@ -37,8 +37,8 @@ type InfoPointProps = {
 
 export default function InfoPoint({
   tooltipSide = "top",
-  drawerTitle,
-  drawerDescription,
+  title,
+  description,
   tooltipContent,
   drawerContent,
   className,
@@ -57,16 +57,18 @@ export default function InfoPoint({
   return (
     <>
       <Tooltip side={tooltipSide} content={tooltipContent}>
-        <CircleQuestionMarkIcon
-          className={className}
+        <button
           onClick={() => setDrawerOpen(isTouchDevice)}
-        />
+          aria-label={description}
+        >
+          <CircleQuestionMarkIcon className={className} />
+        </button>
       </Tooltip>
       <FloatingDrawer
         open={drawerOpen}
         onOpenChange={setDrawerOpen}
-        title={drawerTitle}
-        description={drawerDescription}
+        title={title}
+        description={description}
       >
         {drawerContent}
       </FloatingDrawer>

--- a/frontend/src/components/info-point.tsx
+++ b/frontend/src/components/info-point.tsx
@@ -1,19 +1,50 @@
+import { useEffect, useState } from "react";
+
 import { CircleQuestionMarkIcon } from "lucide-react";
 
+import { FloatingDrawer } from "@/features/drawer";
 import Tooltip from "@/features/system-feedback/tooltip/base";
 
 export default function InfoPoint({
   tooltipSide = "top",
+  title,
+  description,
   content,
   className,
 }: {
   tooltipSide?: "top" | "bottom";
+  title: string;
+  description: string;
   content: React.ReactNode;
   className?: string;
 }) {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [isTouchDevice, setIsTouchDevice] = useState(false);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(pointer: coarse)");
+    setIsTouchDevice(mediaQuery.matches);
+
+    const listener = (e: MediaQueryListEvent) => setIsTouchDevice(e.matches);
+    mediaQuery.addEventListener("change", listener);
+    return () => mediaQuery.removeEventListener("change", listener);
+  }, []);
+
   return (
-    <Tooltip side={tooltipSide} content={content}>
-      <CircleQuestionMarkIcon className={className} />
-    </Tooltip>
+    <>
+      <Tooltip side={tooltipSide} content={content}>
+        <CircleQuestionMarkIcon
+          className={className}
+          onClick={() => setDrawerOpen(isTouchDevice)}
+        />
+      </Tooltip>
+      <FloatingDrawer
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        title={title}
+        description={description}
+      >
+        {content}
+      </FloatingDrawer>
+    </>
   );
 }

--- a/frontend/src/components/info-point.tsx
+++ b/frontend/src/components/info-point.tsx
@@ -5,6 +5,36 @@ import { CircleQuestionMarkIcon } from "lucide-react";
 import { FloatingDrawer } from "@/features/drawer";
 import Tooltip, { TooltipSide } from "@/features/system-feedback/tooltip/base";
 
+type InfoPointProps = {
+  /**
+   * The side the tooltip should appear on when hovering.
+   *
+   * @default "top"
+   */
+  tooltipSide?: TooltipSide;
+  /**
+   * The title displayed on the drawer when tapping the info point on mobile.
+   */
+  drawerTitle: string;
+  /**
+   * Hidden description for the drawer shown on mobile, to aid with accessibility.
+   */
+  drawerDescription: string;
+  /**
+   * The content to be displayed on desktop when hovering the info point.
+   */
+  tooltipContent: React.ReactNode;
+  /**
+   * The content to be displayed on mobile when tapping the info point.
+   */
+  drawerContent: React.ReactNode;
+  /**
+   * Optional styling for the info point icon. Does not affect the content in the tooltip
+   * or drawer.
+   */
+  className?: string;
+};
+
 export default function InfoPoint({
   tooltipSide = "top",
   drawerTitle,
@@ -12,14 +42,7 @@ export default function InfoPoint({
   tooltipContent,
   drawerContent,
   className,
-}: {
-  tooltipSide?: TooltipSide;
-  drawerTitle: string;
-  drawerDescription: string;
-  tooltipContent: React.ReactNode;
-  drawerContent: React.ReactNode;
-  className?: string;
-}) {
+}: InfoPointProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
   useEffect(() => {

--- a/frontend/src/features/account/setting-dialogs/delete-account.tsx
+++ b/frontend/src/features/account/setting-dialogs/delete-account.tsx
@@ -99,7 +99,11 @@ export default function DeleteAccountDialog() {
       onOpenChange={handleOpenChange}
       onConfirm={handleDeleteAccount}
     >
-      <EmptyButton buttonStyle="danger" label="Delete Account" />
+      <EmptyButton
+        buttonStyle="danger"
+        label="Delete Account"
+        tooltip="Woah... be careful!"
+      />
     </ConfirmationDialog>
   );
 }

--- a/frontend/src/features/button/components/action.tsx
+++ b/frontend/src/features/button/components/action.tsx
@@ -12,6 +12,7 @@ const ActionButton = forwardRef<Ref, ActionButtonProps>(
       icon,
       label,
       shrinkOnMobile = false,
+      tooltip,
       loading = false,
       disabled = false,
       onClick,
@@ -28,6 +29,7 @@ const ActionButton = forwardRef<Ref, ActionButtonProps>(
         icon={icon}
         label={label}
         shrinkOnMobile={shrinkOnMobile}
+        tooltip={tooltip}
         loading={loading}
         disabled={disabled}
         onClick={onClick}

--- a/frontend/src/features/button/components/base.tsx
+++ b/frontend/src/features/button/components/base.tsx
@@ -3,15 +3,16 @@
 import {
   ReactElement,
   cloneElement,
+  forwardRef,
   useEffect,
   useState,
-  forwardRef,
 } from "react";
 
 import Link from "next/link";
 
 import LoadingSpinner from "@/components/loading-spinner";
 import { BaseButtonProps, ButtonStyle } from "@/features/button/props";
+import Tooltip from "@/features/system-feedback/tooltip/base";
 import { cn } from "@/lib/utils/classname";
 
 type ButtonState = "rest" | "loading" | "disabled";
@@ -28,6 +29,7 @@ const BaseButton = forwardRef<Ref, BaseButtonProps>(
       icon,
       label,
       shrinkOnMobile = false,
+      tooltip,
       loading = false,
       disabled = false,
       href,
@@ -122,8 +124,10 @@ const BaseButton = forwardRef<Ref, BaseButtonProps>(
       </div>
     );
 
+    let buttonComponent;
+
     if (disabled || isLoading) {
-      return (
+      buttonComponent = (
         <button
           disabled
           type={type}
@@ -134,7 +138,7 @@ const BaseButton = forwardRef<Ref, BaseButtonProps>(
         </button>
       );
     } else if (_buttontype === "link") {
-      return (
+      buttonComponent = (
         <Link
           ref={ref as React.Ref<HTMLAnchorElement>}
           {...props}
@@ -145,7 +149,7 @@ const BaseButton = forwardRef<Ref, BaseButtonProps>(
         </Link>
       );
     } else {
-      return (
+      buttonComponent = (
         <button
           type={type}
           ref={ref as React.Ref<HTMLButtonElement>}
@@ -157,6 +161,12 @@ const BaseButton = forwardRef<Ref, BaseButtonProps>(
         </button>
       );
     }
+
+    if (typeof tooltip !== "undefined") {
+      buttonComponent = <Tooltip content={tooltip}>{buttonComponent}</Tooltip>;
+    }
+
+    return buttonComponent;
   },
 );
 

--- a/frontend/src/features/button/components/base.tsx
+++ b/frontend/src/features/button/components/base.tsx
@@ -162,7 +162,7 @@ const BaseButton = forwardRef<Ref, BaseButtonProps>(
       );
     }
 
-    if (typeof tooltip !== "undefined") {
+    if (tooltip != null) {
       buttonComponent = <Tooltip content={tooltip}>{buttonComponent}</Tooltip>;
     }
 

--- a/frontend/src/features/button/components/empty.tsx
+++ b/frontend/src/features/button/components/empty.tsx
@@ -12,6 +12,7 @@ const EmptyButton = forwardRef<Ref, EmptyButtonProps>(
       icon,
       label,
       shrinkOnMobile = false,
+      tooltip,
       loading = false,
       disabled = false,
       className,
@@ -26,6 +27,7 @@ const EmptyButton = forwardRef<Ref, EmptyButtonProps>(
         icon={icon}
         label={label}
         shrinkOnMobile={shrinkOnMobile}
+        tooltip={tooltip}
         loading={loading}
         disabled={disabled}
         className={className}

--- a/frontend/src/features/button/components/link.tsx
+++ b/frontend/src/features/button/components/link.tsx
@@ -12,6 +12,7 @@ const LinkButton = forwardRef<Ref, LinkButtonProps>(
       icon,
       label,
       shrinkOnMobile = false,
+      tooltip,
       loading = false,
       disabled = false,
       href,
@@ -27,6 +28,7 @@ const LinkButton = forwardRef<Ref, LinkButtonProps>(
         icon={icon}
         label={label}
         shrinkOnMobile={shrinkOnMobile}
+        tooltip={tooltip}
         loading={loading}
         disabled={disabled}
         href={href}

--- a/frontend/src/features/button/props.ts
+++ b/frontend/src/features/button/props.ts
@@ -54,6 +54,13 @@ export type BaseButtonProps = {
    */
   shrinkOnMobile?: boolean;
   /**
+   * A tooltip to show when the button is hovered. This can be a simple string or a more
+   * complex component for more detailed tooltips.
+   *
+   * This tooltip cannot be shown on devices without hover.
+   */
+  tooltip?: ReactNode;
+  /**
    * If `true`, the button will show a loading spinner and be unclickable.
    *
    * Typically, the loading state is managed internally by the button when `onClick` is
@@ -106,6 +113,8 @@ type CommonButtonProps = {
   label?: string;
   /** @inheritdoc BaseButtonProps */
   shrinkOnMobile?: boolean;
+  /** @inheritdoc BaseButtonProps */
+  tooltip?: ReactNode;
   /** @inheritdoc BaseButtonProps */
   loading?: boolean;
   /** @inheritdoc BaseButtonProps */

--- a/frontend/src/features/dashboard/components/event.tsx
+++ b/frontend/src/features/dashboard/components/event.tsx
@@ -9,6 +9,8 @@ import DashboardCopyButton from "@/features/dashboard/components/copy-button";
 import DateRangeRow from "@/features/dashboard/components/date-range-row";
 import ParticipantRow from "@/features/dashboard/components/participant-row";
 import WeekdayRow from "@/features/dashboard/components/weekday-row";
+import Tooltip from "@/features/system-feedback/tooltip/base";
+import useCheckMobile from "@/lib/hooks/use-check-mobile";
 import { cn } from "@/lib/utils/classname";
 import {
   formatTimeRange,
@@ -40,6 +42,7 @@ export default function DashboardEvent({
   ...dateTimeProps
 }: DashboardEventProps) {
   const router = useRouter();
+  const isMobile = useCheckMobile();
 
   function handleDelete(e: MouseEvent<HTMLButtonElement>) {
     e.preventDefault(); // prevent the link behind it triggering
@@ -92,6 +95,68 @@ export default function DashboardEvent({
     return () => observer.disconnect();
   }, []);
 
+  // Dynamic tooltip for the title only if it's too long
+  const titleRef = useRef<HTMLDivElement>(null);
+  const [titleOverflowed, setTitleOverflowed] = useState(false);
+  useEffect(() => {
+    const currentTitleRef = titleRef.current;
+    if (!currentTitleRef) return;
+
+    const checkOverflow = () => {
+      // Create a temporary element to measure the full title width
+      const tempSpan = document.createElement("span");
+      // Copy style of real title
+      const computedStyle = window.getComputedStyle(currentTitleRef);
+      tempSpan.style.fontSize = computedStyle.fontSize;
+      tempSpan.style.fontWeight = computedStyle.fontWeight;
+      tempSpan.style.fontFamily = computedStyle.fontFamily;
+      tempSpan.style.letterSpacing = computedStyle.letterSpacing;
+      tempSpan.style.whiteSpace = "nowrap";
+      tempSpan.style.position = "absolute"; // Don't affect layout
+      tempSpan.style.visibility = "hidden"; // Don't show it
+
+      tempSpan.textContent = currentTitleRef.textContent;
+      document.body.appendChild(tempSpan);
+
+      const contentWidth = tempSpan.offsetWidth;
+      const containerWidth = currentTitleRef.clientWidth;
+
+      setTitleOverflowed(contentWidth > containerWidth);
+
+      document.body.removeChild(tempSpan);
+    };
+
+    checkOverflow();
+
+    const observer = new ResizeObserver(checkOverflow);
+    observer.observe(currentTitleRef);
+
+    // Observe the parent
+    if (currentTitleRef.parentElement) {
+      observer.observe(currentTitleRef.parentElement);
+    }
+
+    return () => observer.disconnect();
+  }, []);
+  let titleContent = (
+    <div
+      ref={titleRef}
+      className={cn(
+        "md:overflow-hidden md:overflow-ellipsis md:whitespace-nowrap",
+        "text-lg font-bold leading-tight",
+      )}
+    >
+      {title}
+    </div>
+  );
+  if (titleOverflowed && !isMobile) {
+    titleContent = (
+      <Tooltip side="top" content={title}>
+        {titleContent}
+      </Tooltip>
+    );
+  }
+
   return (
     <Link
       href={`/${code}`}
@@ -101,7 +166,7 @@ export default function DashboardEvent({
         "[&:not(:has([data-actions]:active))]:active:bg-[color-mix(in_oklab,var(--color-background)_95%,var(--color-black))]",
       )}
     >
-      <div className="text-lg font-bold leading-tight">{title}</div>
+      {titleContent}
       <div className="text-sm opacity-50">{code}</div>
       <div className="mb-2 mt-1">
         {type === "specific" && (

--- a/frontend/src/features/dashboard/components/event.tsx
+++ b/frontend/src/features/dashboard/components/event.tsx
@@ -187,31 +187,35 @@ export default function DashboardEvent({
         <DashboardCopyButton code={code} />
         {myEvent && (
           <>
-            <button className="cursor-pointer" onClick={navigateToEdit}>
-              <div
-                className={cn(
-                  "border-foreground w-fit rounded-full border p-1.5",
-                  "hover:bg-foreground/20 active:bg-foreground/10",
-                )}
+            <Tooltip content="Edit Event">
+              <button className="cursor-pointer" onClick={navigateToEdit}>
+                <div
+                  className={cn(
+                    "border-foreground w-fit rounded-full border p-1.5",
+                    "hover:bg-foreground/20 active:bg-foreground/10",
+                  )}
+                >
+                  <PencilIcon className="h-4 w-4" />
+                </div>
+              </button>
+            </Tooltip>
+            <Tooltip content="Delete Event">
+              <button
+                className="cursor-pointer"
+                onClick={handleDelete}
+                aria-label="Delete Event"
               >
-                <PencilIcon className="h-4 w-4" />
-              </div>
-            </button>
-            <button
-              className="cursor-pointer"
-              onClick={handleDelete}
-              aria-label="Delete Event"
-            >
-              <div
-                className={cn(
-                  "border-foreground w-fit rounded-full border p-1.5",
-                  "hover:bg-error/20 hover:text-error hover:border-error",
-                  "active:bg-error/40",
-                )}
-              >
-                <Trash2Icon className="h-4 w-4" />
-              </div>
-            </button>
+                <div
+                  className={cn(
+                    "border-foreground w-fit rounded-full border p-1.5",
+                    "hover:bg-error/20 hover:text-error hover:border-error",
+                    "active:bg-error/40",
+                  )}
+                >
+                  <Trash2Icon className="h-4 w-4" />
+                </div>
+              </button>
+            </Tooltip>
           </>
         )}
       </div>

--- a/frontend/src/features/dashboard/components/participant-row.tsx
+++ b/frontend/src/features/dashboard/components/participant-row.tsx
@@ -53,7 +53,10 @@ export default function ParticipantRow({
 
   if (participants.length > 0) {
     rowContent = (
-      <Tooltip content={<TooltipContent participants={participants} />}>
+      <Tooltip
+        content={<TooltipContent participants={participants} />}
+        maxHeight="384px"
+      >
         {rowContent}
       </Tooltip>
     );

--- a/frontend/src/features/dashboard/components/participant-row.tsx
+++ b/frontend/src/features/dashboard/components/participant-row.tsx
@@ -1,3 +1,4 @@
+import Tooltip from "@/features/system-feedback/tooltip/base";
 import { cn } from "@/lib/utils/classname";
 
 type ParticipantRowProps = {
@@ -9,10 +10,10 @@ export default function ParticipantRow({
   participants,
   numIcons,
 }: ParticipantRowProps) {
-  return (
+  let rowContent = (
     <div
       className={cn(
-        "flex bg-inherit text-sm",
+        "flex w-fit bg-inherit text-sm",
         // Every icon after the first has padding meant to act as a border
         Math.min(numIcons, participants.length) > 1 && "-mb-0.5",
       )}
@@ -49,6 +50,16 @@ export default function ParticipantRow({
       )}
     </div>
   );
+
+  if (participants.length > 0) {
+    rowContent = (
+      <Tooltip content={<TooltipContent participants={participants} />}>
+        {rowContent}
+      </Tooltip>
+    );
+  }
+
+  return rowContent;
 }
 
 function ParticipantIcon({
@@ -98,6 +109,26 @@ function ParticipantIcon({
           iconText
         )}
       </div>
+    </div>
+  );
+}
+
+function TooltipContent({ participants }: { participants: string[] }) {
+  return (
+    <div className="flex flex-col">
+      <div className="text-center font-bold">
+        {participants.length} Attendee{participants.length !== 1 ? "s" : ""}
+      </div>
+      <ul>
+        {participants.map((participant) => (
+          <li
+            key={participant}
+            className="whitespace-nowrap text-center text-sm"
+          >
+            {participant}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/frontend/src/features/event/editor/advanced-options.tsx
+++ b/frontend/src/features/event/editor/advanced-options.tsx
@@ -127,8 +127,8 @@ function Options({ isEditing = false, errors }: AdvancedOptionsProps) {
               </div>
             </label>
             <InfoPoint
-              drawerTitle="Custom Event Codes"
-              drawerDescription="More information about custom event codes"
+              title="Custom Event Codes"
+              description="More information about custom event codes"
               tooltipContent={
                 <div className="max-w-3xs p-1">{customCodeInfo}</div>
               }

--- a/frontend/src/features/event/editor/advanced-options.tsx
+++ b/frontend/src/features/event/editor/advanced-options.tsx
@@ -4,6 +4,7 @@ import * as Collapsible from "@radix-ui/react-collapsible";
 import { ChevronRightIcon, TriangleAlertIcon } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 
+import InfoPoint from "@/components/info-point";
 import { useEventContext } from "@/core/event/context";
 import TimeZoneSelector from "@/features/event/components/selectors/timezone";
 import { MESSAGES } from "@/lib/messages";
@@ -92,15 +93,50 @@ function Options({ isEditing = false, errors }: AdvancedOptionsProps) {
       </div>
 
       <div className="flex flex-col gap-1">
-        <label
-          htmlFor="custom-code-input"
-          className="flex justify-between font-bold"
-        >
-          {!isEditing && "Custom"} Event Code
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <label
+              htmlFor="custom-code-input"
+              className="flex justify-between font-bold"
+            >
+              <div className="flex items-center gap-2">
+                {!isEditing && "Custom"} Event Code
+              </div>
+            </label>
+            <InfoPoint
+              content={
+                <div className="flex max-w-64 flex-col gap-2 p-1">
+                  <div>
+                    Each Plancake event is identified by a code, used in its
+                    unique link.
+                  </div>
+                  <div>
+                    For the code <span className="font-bold">abcd1234</span>,
+                    the link would be:{" "}
+                    <span className="underline">
+                      {window.location.host}/
+                      <span className="font-bold">abcd1234</span>
+                    </span>
+                  </div>
+                  {isEditing ? (
+                    <div>
+                      You can{"'"}t change this code after an event is created.
+                    </div>
+                  ) : (
+                    <div>
+                      You can provide a custom code for this event (subject to
+                      availability), otherwise we{"'"}ll generate one for you.
+                    </div>
+                  )}
+                </div>
+              }
+              className="h-5 w-5 opacity-75"
+            />
+          </div>
           {errors.customCode && (
             <TriangleAlertIcon className="text-error h-4 w-4" />
           )}
-        </label>
+        </div>
         <input
           id="custom-code-input"
           type="text"

--- a/frontend/src/features/event/editor/advanced-options.tsx
+++ b/frontend/src/features/event/editor/advanced-options.tsx
@@ -104,6 +104,8 @@ function Options({ isEditing = false, errors }: AdvancedOptionsProps) {
               </div>
             </label>
             <InfoPoint
+              title="Custom Event Codes"
+              description="More information about custom event codes"
               content={
                 <div className="flex max-w-64 flex-col gap-2 p-1">
                   <div>

--- a/frontend/src/features/event/editor/advanced-options.tsx
+++ b/frontend/src/features/event/editor/advanced-options.tsx
@@ -79,24 +79,20 @@ function Options({ isEditing = false, errors }: AdvancedOptionsProps) {
 
   const customCodeInfo = (
     <div className="flex flex-col gap-2">
-      <div>
-        Each Plancake event is identified by a code, used in its unique link.
-      </div>
-      <div>
-        For the code <span className="font-bold">abcd1234</span>, the link would
-        be:{" "}
-        <span className="underline">
-          {typeof window === "undefined" ? "" : window.location.host}/
-          <span className="font-bold">abcd1234</span>
-        </span>
-      </div>
       {isEditing ? (
-        <div>You can{"'"}t change this code after an event is created.</div>
+        <div>The event code cannot be changed after the event is created.</div>
       ) : (
-        <div>
-          You can provide a custom code for this event (subject to
-          availability), otherwise we{"'"}ll generate one for you.
-        </div>
+        <>
+          <div>You have the option to customize your event link.</div>
+          <div>
+            For example, the link for custom code{" "}
+            <span className="font-bold">breakfast</span> would be:{" "}
+            <span className="underline">
+              {typeof window === "undefined" ? "" : window.location.host}/
+              <span className="font-bold">breakfast</span>
+            </span>
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/features/event/editor/advanced-options.tsx
+++ b/frontend/src/features/event/editor/advanced-options.tsx
@@ -86,7 +86,8 @@ function Options({ isEditing = false, errors }: AdvancedOptionsProps) {
         For the code <span className="font-bold">abcd1234</span>, the link would
         be:{" "}
         <span className="underline">
-          {window.location.host}/<span className="font-bold">abcd1234</span>
+          {typeof window === "undefined" ? "" : window.location.host}/
+          <span className="font-bold">abcd1234</span>
         </span>
       </div>
       {isEditing ? (

--- a/frontend/src/features/event/editor/advanced-options.tsx
+++ b/frontend/src/features/event/editor/advanced-options.tsx
@@ -77,6 +77,29 @@ function Options({ isEditing = false, errors }: AdvancedOptionsProps) {
     checkCodeAvailability(newValue);
   };
 
+  const customCodeInfo = (
+    <div className="flex flex-col gap-2">
+      <div>
+        Each Plancake event is identified by a code, used in its unique link.
+      </div>
+      <div>
+        For the code <span className="font-bold">abcd1234</span>, the link would
+        be:{" "}
+        <span className="underline">
+          {window.location.host}/<span className="font-bold">abcd1234</span>
+        </span>
+      </div>
+      {isEditing ? (
+        <div>You can{"'"}t change this code after an event is created.</div>
+      ) : (
+        <div>
+          You can provide a custom code for this event (subject to
+          availability), otherwise we{"'"}ll generate one for you.
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <>
       <div className="flex flex-col gap-1">
@@ -104,34 +127,12 @@ function Options({ isEditing = false, errors }: AdvancedOptionsProps) {
               </div>
             </label>
             <InfoPoint
-              title="Custom Event Codes"
-              description="More information about custom event codes"
-              content={
-                <div className="flex max-w-64 flex-col gap-2 p-1">
-                  <div>
-                    Each Plancake event is identified by a code, used in its
-                    unique link.
-                  </div>
-                  <div>
-                    For the code <span className="font-bold">abcd1234</span>,
-                    the link would be:{" "}
-                    <span className="underline">
-                      {window.location.host}/
-                      <span className="font-bold">abcd1234</span>
-                    </span>
-                  </div>
-                  {isEditing ? (
-                    <div>
-                      You can{"'"}t change this code after an event is created.
-                    </div>
-                  ) : (
-                    <div>
-                      You can provide a custom code for this event (subject to
-                      availability), otherwise we{"'"}ll generate one for you.
-                    </div>
-                  )}
-                </div>
+              drawerTitle="Custom Event Codes"
+              drawerDescription="More information about custom event codes"
+              tooltipContent={
+                <div className="max-w-3xs p-1">{customCodeInfo}</div>
               }
+              drawerContent={customCodeInfo}
               className="h-5 w-5 opacity-75"
             />
           </div>

--- a/frontend/src/features/event/grid/schedule-header.tsx
+++ b/frontend/src/features/event/grid/schedule-header.tsx
@@ -70,6 +70,7 @@ export default function ScheduleHeader({
             onClick={onPrevPage}
             className="ml-3 p-1.5"
             aria-label="Previous Page"
+            tooltip="Previous Page"
           />
         </div>
       ) : (
@@ -121,6 +122,7 @@ export default function ScheduleHeader({
             onClick={onNextPage}
             className="p-1.5"
             aria-label="Next Page"
+            tooltip="Next Page"
           />
         </div>
       ) : (

--- a/frontend/src/features/event/results/attendee-panel/panel-header.tsx
+++ b/frontend/src/features/event/results/attendee-panel/panel-header.tsx
@@ -106,6 +106,7 @@ export default function PanelHeader({
               !hasSelection && "pointer-events-none opacity-0",
             )}
             aria-label="Clear Selection"
+            tooltip="Clear Selection"
           />
 
           {isCreator && (
@@ -113,7 +114,8 @@ export default function PanelHeader({
               buttonStyle="semi-transparent"
               icon={isRemoving ? <CheckIcon /> : <EraserIcon />}
               onClick={toggleRemoving}
-              aria-label={isRemoving ? "Stop Removing" : "Remove Participants"}
+              aria-label={isRemoving ? "Stop Removing" : "Remove Attendees"}
+              tooltip={isRemoving ? "Stop Removing" : "Remove Attendees"}
               className={cn(
                 "shrink-0",
                 !isRemoving &&
@@ -130,6 +132,7 @@ export default function PanelHeader({
                 promptRemove(currentUser);
               }}
               aria-label="Leave Event"
+              tooltip="Leave Event"
               className="hover:bg-error/25 hover:text-error active:bg-error/40 shrink-0"
             />
           )}

--- a/frontend/src/features/header/components/account-button.tsx
+++ b/frontend/src/features/header/components/account-button.tsx
@@ -71,7 +71,8 @@ export default function AccountButton() {
               className="relative z-10"
               buttonStyle="frosted glass inset"
               icon={<UserIcon />}
-              aria-label="Account settings"
+              aria-label="Account"
+              tooltip="Account"
             />
           }
         >

--- a/frontend/src/features/header/components/dashboard-button.tsx
+++ b/frontend/src/features/header/components/dashboard-button.tsx
@@ -13,6 +13,7 @@ export default function DashboardButton() {
         buttonStyle="frosted glass inset"
         icon={<LayoutDashboardIcon className="h-5 w-5" />}
         href="/dashboard"
+        tooltip="Dashboard"
       />
     </ShrinkingHeaderButton>
   );

--- a/frontend/src/features/header/components/theme-picker.tsx
+++ b/frontend/src/features/header/components/theme-picker.tsx
@@ -30,6 +30,7 @@ export default function ThemePicker() {
             buttonStyle="frosted glass inset"
             icon={<SunMoonIcon />}
             aria-label="Choose Site Theme"
+            tooltip="Theme"
           />
         }
         closeOnClick={false}

--- a/frontend/src/features/system-feedback/tooltip/base.tsx
+++ b/frontend/src/features/system-feedback/tooltip/base.tsx
@@ -35,7 +35,7 @@ export default function Tooltip({
           sideOffset={4}
           className={cn(
             "bg-foreground text-background text-sm",
-            "max-w-screen z-100 rounded-2xl px-2 py-1",
+            "max-w-screen z-[100] rounded-2xl px-2 py-1",
             "shadow-lg will-change-transform",
             "data-[state=delayed-open]:animate-tooltipOpen",
             "data-[state=instant-open]:animate-tooltipOpen",

--- a/frontend/src/features/system-feedback/tooltip/base.tsx
+++ b/frontend/src/features/system-feedback/tooltip/base.tsx
@@ -1,0 +1,39 @@
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils/classname";
+
+type TooltipProps = {
+  side?: "top" | "bottom";
+  content: React.ReactNode;
+  children: React.ReactNode;
+};
+
+export default function Tooltip({
+  side = "bottom",
+  content,
+  children,
+}: TooltipProps) {
+  return (
+    <TooltipPrimitive.Root>
+      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+      <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+          side={side}
+          align="center"
+          sideOffset={4}
+          className={cn(
+            "bg-foreground text-background text-sm",
+            "max-w-screen z-100 rounded-2xl px-2 py-1",
+            "shadow-lg will-change-transform",
+            "data-[state=delayed-open]:animate-slideUpAndFade",
+            "data-[state=instant-open]:animate-slideUpAndFade",
+            "data-[state=closed]:animate-slideDownAndFadeOut",
+          )}
+        >
+          {content}
+          <TooltipPrimitive.Arrow className="fill-foreground" />
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Portal>
+    </TooltipPrimitive.Root>
+  );
+}

--- a/frontend/src/features/system-feedback/tooltip/base.tsx
+++ b/frontend/src/features/system-feedback/tooltip/base.tsx
@@ -15,6 +15,11 @@ type TooltipProps = {
    */
   content: React.ReactNode;
   /**
+   * Optional maximum height for the tooltip. If the content is taller than this, it will
+   * become scrollable.
+   */
+  maxHeight?: string;
+  /**
    * The element that triggers the tooltip when hovered.
    */
   children: React.ReactNode;
@@ -23,6 +28,7 @@ type TooltipProps = {
 export default function Tooltip({
   side = "bottom",
   content,
+  maxHeight,
   children,
 }: TooltipProps) {
   return (
@@ -35,14 +41,19 @@ export default function Tooltip({
           sideOffset={4}
           className={cn(
             "bg-foreground text-background text-sm",
-            "max-w-screen z-[100] rounded-2xl px-2 py-1",
+            "max-w-screen z-[100] rounded-2xl",
             "shadow-lg will-change-transform",
             "data-[state=delayed-open]:animate-tooltipOpen",
             "data-[state=instant-open]:animate-tooltipOpen",
             "data-[state=closed]:animate-tooltipClose",
           )}
         >
-          {content}
+          <div
+            className={cn("px-2 py-1", maxHeight && "overflow-y-auto")}
+            style={maxHeight ? { maxHeight } : undefined}
+          >
+            {content}
+          </div>
           <TooltipPrimitive.Arrow className="fill-foreground" />
         </TooltipPrimitive.Content>
       </TooltipPrimitive.Portal>

--- a/frontend/src/features/system-feedback/tooltip/base.tsx
+++ b/frontend/src/features/system-feedback/tooltip/base.tsx
@@ -35,9 +35,9 @@ export default function Tooltip({
             "bg-foreground text-background text-sm",
             "max-w-screen z-100 rounded-2xl px-2 py-1",
             "shadow-lg will-change-transform",
-            "data-[state=delayed-open]:animate-slideUpAndFade",
-            "data-[state=instant-open]:animate-slideUpAndFade",
-            "data-[state=closed]:animate-slideDownAndFadeOut",
+            "data-[state=delayed-open]:animate-tooltipOpen",
+            "data-[state=instant-open]:animate-tooltipOpen",
+            "data-[state=closed]:animate-tooltipClose",
           )}
         >
           {content}

--- a/frontend/src/features/system-feedback/tooltip/base.tsx
+++ b/frontend/src/features/system-feedback/tooltip/base.tsx
@@ -3,8 +3,18 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cn } from "@/lib/utils/classname";
 
 type TooltipProps = {
+  /**
+   * The side the tooltip should appear on. Defaults to "bottom".
+   */
   side?: "top" | "bottom";
+  /**
+   * The content to be displayed in the tooltip. For most cases, this will just be a
+   * string, but it can be any content for a more detailed tooltip.
+   */
   content: React.ReactNode;
+  /**
+   * The element that triggers the tooltip when hovered.
+   */
   children: React.ReactNode;
 };
 

--- a/frontend/src/features/system-feedback/tooltip/base.tsx
+++ b/frontend/src/features/system-feedback/tooltip/base.tsx
@@ -2,11 +2,13 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 import { cn } from "@/lib/utils/classname";
 
+export type TooltipSide = "top" | "bottom";
+
 type TooltipProps = {
   /**
    * The side the tooltip should appear on. Defaults to "bottom".
    */
-  side?: "top" | "bottom";
+  side?: TooltipSide;
   /**
    * The content to be displayed in the tooltip. For most cases, this will just be a
    * string, but it can be any content for a more detailed tooltip.

--- a/frontend/src/lib/providers.tsx
+++ b/frontend/src/lib/providers.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { LucideProvider } from "lucide-react";
 import { ThemeProvider } from "next-themes";
 
@@ -20,7 +21,11 @@ export function Providers({
       <LucideProvider absoluteStrokeWidth={true} strokeWidth={1.5}>
         <AccountProvider accountDetails={accountDetails}>
           <HeaderSizeProvider>
-            <ToastProvider>{children}</ToastProvider>
+            <ToastProvider>
+              <TooltipProvider delayDuration={300} skipDelayDuration={500}>
+                {children}
+              </TooltipProvider>
+            </ToastProvider>
           </HeaderSizeProvider>
         </AccountProvider>
       </LucideProvider>

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -138,6 +138,9 @@
   --animate-slideOut: slideOut 400ms cubic-bezier(0.16, 1, 0.3, 1);
   --animate-swipeOut: swipeOut 100ms ease-out;
 
+  --animate-tooltipOpen: slideUpAndFade 150ms;
+  --animate-tooltipClose: slideDownAndFadeOut 150ms;
+
   @keyframes hide {
     0% {
       opacity: 1;


### PR DESCRIPTION
This PR introduces tooltips to the site.

### New Tooltips
Using the Radix UI primitive, the new `Tooltip` component was created that can be wrapped around any element to give it a tooltip on hover.

The content of these tooltips can be anything, but in most cases it will just be a string. They also only show on desktop, since there's no way to hover on mobile.

These tooltips were also integrated directly with buttons, meaning that you just have to pass the tooltip content into the `tooltip` prop to get it working.

### Info Point Component
The `InfoPoint` component was created to help users when they might want more info. On desktop, it shows a tooltip on hover. On mobile, it opens a drawer on tap. The content for the tooltip and drawer can be separately customized.

Right now, this was only implemented next to the "Custom Event Code" field in the event editor.

### Dashboard Integration
Finally, the dashboard tile size is now consistent. Titles longer than one line are cut off with an ellipsis, showing the full title on hover in a tooltip.
- This is disabled on the mobile view, and titles are allowed to span multiple lines there. It's only one column, and mobile users wouldn't be able to see the tooltip anyway.

The participant row now has a tooltip on hover, showing the names of all participants.