### PR TITLE
Update code checking rate limit

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -125,7 +125,7 @@ REST_FRAMEWORK = {
         ThrottleScopes.PASSWORD_RESET.key: "10/hour",
         ThrottleScopes.EVENT_CREATION.key: "25/hour",
         ThrottleScopes.AVAILABILITY_ADD.key: "50/hour",
-        ThrottleScopes.CODE_CHECK.key: "50/hour",
+        ThrottleScopes.CODE_CHECK.key: "10/min",
     },
 }
 


### PR DESCRIPTION
This PR changes the auth-code-checking rate limit to a per-minute limit rather than per-hour. This prevents users from being locked out of creating an account or changing their password for an entire hour.

This much more generous limit is not a problem because codes expire in 10 minutes, meaning a brute-force attack won't get very far anyway.