### PR TITLE
Fix `globals.css` import error

### DIFF
--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,0 +1,2 @@
+// Silences an error when importing globals.css in layout.tsx
+declare module "*.css";


### PR DESCRIPTION
The linter didn't like us importing CSS in the way Next.js recommended. Creating `src/global.d.ts` and declaring CSS files as valid modules fixed it.