### PR TITLE
Fix mobile results footer behavior

### DIFF
--- a/frontend/src/features/drawer/components/base.tsx
+++ b/frontend/src/features/drawer/components/base.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { XIcon } from "lucide-react";
 import { Drawer } from "vaul";
@@ -35,10 +35,20 @@ export default function BaseDrawer({
 
   const contentRef = useRef<HTMLDivElement>(null);
   const wasDraggingRef = useRef(false);
+  const animatingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
 
   useVaulStickyFooter(contentRef, isDragging || isAnimating);
+
+  // Animating timeout cleanup
+  useEffect(() => {
+    return () => {
+      if (animatingTimeoutRef.current) {
+        clearTimeout(animatingTimeoutRef.current);
+      }
+    };
+  }, []);
 
   /**
    * CONDITIONAL PROPS BASED ON VARIANT
@@ -188,10 +198,17 @@ export default function BaseDrawer({
                 onClick={() => {
                   if (wasDraggingRef.current) return;
                   if (isPill) {
+                    if (animatingTimeoutRef.current) {
+                      clearTimeout(animatingTimeoutRef.current);
+                    }
+
                     setIsAnimating(true);
                     setSnap(snapPoints?.[1] ?? null);
                     // Let the footer observer update before setting isAnimating to false
-                    setTimeout(() => setIsAnimating(false), 0);
+                    animatingTimeoutRef.current = setTimeout(() => {
+                      setIsAnimating(false);
+                      animatingTimeoutRef.current = null;
+                    }, 0);
                   }
                 }}
                 className={cn(

--- a/frontend/src/features/drawer/components/base.tsx
+++ b/frontend/src/features/drawer/components/base.tsx
@@ -190,7 +190,8 @@ export default function BaseDrawer({
                   if (isPill) {
                     setIsAnimating(true);
                     setSnap(snapPoints?.[1] ?? null);
-                    setIsAnimating(false);
+                    // Let the footer observer update before setting isAnimating to false
+                    setTimeout(() => setIsAnimating(false), 0);
                   }
                 }}
                 className={cn(


### PR DESCRIPTION
There was a bug where the mobile results drawer footer wouldn't display if you tapped on the drawer to open it.

By adding a delay on setting `isAnimating` back to false after the transition, it allows the observer in the footer to update its position and display normally.