### PR TITLE
Token log removal

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -195,7 +195,7 @@ LOGGING = {
             "class": "logging.handlers.RotatingFileHandler",
             "filename": f"{LOG_DIR}/django.log",
             "formatter": "verbose",
-            "level": "DEBUG",
+            "level": "DEBUG" if DEBUG else "INFO",
             "maxBytes": 1024 * 1024 * 5,  # 5 MB
             "backupCount": 5,
         },


### PR DESCRIPTION
This PR changes the production logging to exclude the `DEBUG` severity, which would include session tokens and password reset codes.