### PR TITLE
Automatic confirmation dialog drawer

### DIFF
--- a/frontend/src/features/system-feedback/dialog/components/confirmation.tsx
+++ b/frontend/src/features/system-feedback/dialog/components/confirmation.tsx
@@ -4,6 +4,7 @@ import ActionButton from "@/features/button/components/action";
 import BaseModal from "@/features/system-feedback/dialog/components/base";
 import { DIALOG_CONFIG } from "@/features/system-feedback/dialog/config";
 import { ConfirmationDialogProps } from "@/features/system-feedback/dialog/props";
+import useCheckMobile from "@/lib/hooks/use-check-mobile";
 import { cn } from "@/lib/utils/classname";
 
 export default function ConfirmationDialog({
@@ -25,6 +26,11 @@ export default function ConfirmationDialog({
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  const isMobile = useCheckMobile();
+  if (isMobile && !asNestedDrawer) {
+    asNestedDrawer = true;
+  }
 
   const handleOpenChange = useCallback(
     (newOpen: boolean) => {


### PR DESCRIPTION
This PR adds a small bit of logic to the `ConfirmationDialog` component such that, if it's on mobile, it will automatically convert to a drawer instead of a dialog.