### PR TITLE
Fix date selector trigger area

### DIFF
--- a/frontend/src/features/event/editor/date-range/selector.tsx
+++ b/frontend/src/features/event/editor/date-range/selector.tsx
@@ -26,7 +26,7 @@ export default function DateRangeSelection({
         </label>
         <EventTypeSelect id="event-type-select" disabled={editing} />
       </div>
-      <div className="flex w-fit flex-col justify-center gap-1">
+      <div className="flex w-fit flex-col gap-1">
         <p
           className={`flex items-center gap-2 font-bold ${errors.dateRange || errors.weekdayRange ? "text-error" : ""}`}
         >

--- a/frontend/src/features/event/editor/date-range/selector.tsx
+++ b/frontend/src/features/event/editor/date-range/selector.tsx
@@ -26,7 +26,7 @@ export default function DateRangeSelection({
         </label>
         <EventTypeSelect id="event-type-select" disabled={editing} />
       </div>
-      <div className="flex w-full flex-col justify-center gap-1">
+      <div className="flex w-fit flex-col justify-center gap-1">
         <p
           className={`flex items-center gap-2 font-bold ${errors.dateRange || errors.weekdayRange ? "text-error" : ""}`}
         >


### PR DESCRIPTION
The date selector had `w-full`, meaning it would open the calendar picker if clicking anywhere on the right side of it. That's been removed.