### PR TITLE
Pointer-type-aware panel header text

### DIFF
--- a/frontend/src/components/info-point.tsx
+++ b/frontend/src/components/info-point.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { CircleQuestionMarkIcon } from "lucide-react";
 
 import { FloatingDrawer } from "@/features/drawer";
 import Tooltip, { TooltipSide } from "@/features/system-feedback/tooltip/base";
+import usePointerType from "@/lib/hooks/use-pointer-type";
 
 type InfoPointProps = {
   /**
@@ -44,21 +45,13 @@ export default function InfoPoint({
   className,
 }: InfoPointProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(pointer: coarse)");
-    setIsTouchDevice(mediaQuery.matches);
-
-    const listener = (e: MediaQueryListEvent) => setIsTouchDevice(e.matches);
-    mediaQuery.addEventListener("change", listener);
-    return () => mediaQuery.removeEventListener("change", listener);
-  }, []);
+  const pointerType = usePointerType();
 
   return (
     <>
       <Tooltip side={tooltipSide} content={tooltipContent}>
         <button
-          onClick={() => setDrawerOpen(isTouchDevice)}
+          onClick={() => setDrawerOpen(pointerType === "coarse")}
           aria-label={description}
         >
           <CircleQuestionMarkIcon className={className} />

--- a/frontend/src/features/event/results/attendees/panel-header.tsx
+++ b/frontend/src/features/event/results/attendees/panel-header.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, DoorOpenIcon, EraserIcon, Undo2Icon } from "lucide-react";
 
 import ActionButton from "@/features/button/components/action";
 import { useResultsContext } from "@/features/event/results/context";
+import usePointerType from "@/lib/hooks/use-pointer-type";
 import { cn } from "@/lib/utils/classname";
 
 type PanelHeaderProps = {
@@ -46,6 +47,8 @@ export default function PanelHeader({
     !isCreator &&
     currentUser &&
     participants.some((p) => p.display_name === currentUser);
+
+  const pointerType = usePointerType();
 
   const formatHoveredSlot = () => {
     const date = new Date(hoveredSlot!);
@@ -125,9 +128,13 @@ export default function PanelHeader({
         {gridNumParticipants > 0 && (
           <span className="text-sm opacity-75">
             {isRemoving
-              ? `Select to remove`
+              ? pointerType === "coarse"
+                ? "Tap to remove"
+                : "Click to remove"
               : hoveredSlot === null
-                ? "Hover grid for availability"
+                ? pointerType === "coarse"
+                  ? "Tap grid for availability"
+                  : "Hover grid for availability"
                 : formatHoveredSlot()}
           </span>
         )}

--- a/frontend/src/lib/hooks/use-pointer-type.ts
+++ b/frontend/src/lib/hooks/use-pointer-type.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type PointerType = "coarse" | "fine";
+
+export default function usePointerType() {
+  const [pointerType, setPointerType] = useState<PointerType>();
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(pointer: coarse)");
+    setPointerType(mediaQuery.matches ? "coarse" : "fine");
+
+    const listener = (e: MediaQueryListEvent) =>
+      setPointerType(e.matches ? "coarse" : "fine");
+    mediaQuery.addEventListener("change", listener);
+    return () => mediaQuery.removeEventListener("change", listener);
+  }, []);
+
+  return pointerType;
+}

--- a/frontend/src/lib/hooks/use-pointer-type.ts
+++ b/frontend/src/lib/hooks/use-pointer-type.ts
@@ -5,6 +5,10 @@ import { useEffect, useState } from "react";
 type PointerType = "coarse" | "fine";
 
 export default function usePointerType() {
+  /**
+   * This initial null state is used to give the option to render a fallback/placeholder
+   * before the actual pointer type is determined.
+   */
   const [pointerType, setPointerType] = useState<PointerType | null>(null);
   useEffect(() => {
     const mediaQuery = window.matchMedia("(pointer: coarse)");

--- a/frontend/src/lib/hooks/use-pointer-type.ts
+++ b/frontend/src/lib/hooks/use-pointer-type.ts
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 type PointerType = "coarse" | "fine";
 
 export default function usePointerType() {
-  const [pointerType, setPointerType] = useState<PointerType>();
+  const [pointerType, setPointerType] = useState<PointerType | null>(null);
   useEffect(() => {
     const mediaQuery = window.matchMedia("(pointer: coarse)");
     setPointerType(mediaQuery.matches ? "coarse" : "fine");


### PR DESCRIPTION
This PR makes some minor changes to the results panel header text, making it more device-aware.

### Panel Text Updates
The text is now aware of the type of device used:
- "Hover grid for availability"
    - For devices with a mouse, remains the same
    - For touch devices, it is now "Tap grid for availability"
- "Select to remove" (when removing attendees)
    - For devices with a mouse, it is now "Click to remove"
    - For touch devices, it is now "Tap to remove"

### New `usePointerType` Hook
The pointer type was checked in the `InfoPoint` to determine whether the tooltip would show, versus a drawer on tap. This logic was moved to a separate hook so it can be reused.