### PR TITLE
Add relevant titles to time selectors

### DIFF
--- a/frontend/src/features/event/components/selectors/time.tsx
+++ b/frontend/src/features/event/components/selectors/time.tsx
@@ -2,9 +2,10 @@ import Selector from "@/features/selector/components/selector";
 import { BaseSelectorWrapperProps } from "@/features/selector/types";
 import { convert12To24 } from "@/lib/utils/date-time-format";
 
-export default function TimeSelector(
-  props: BaseSelectorWrapperProps<string | null>,
-) {
+export default function TimeSelector({
+  dialogTitle,
+  ...props
+}: { dialogTitle: string } & BaseSelectorWrapperProps<string | null>) {
   const options = Array.from({ length: 24 }, (_, i) => {
     const hour = i % 12 === 0 ? 12 : i % 12;
     const period = i < 12 ? "am" : "pm";
@@ -21,7 +22,7 @@ export default function TimeSelector(
     <Selector
       {...props}
       options={options}
-      dialogTitle="Select Time"
+      dialogTitle={dialogTitle}
       dialogDescription="Select a time from the list"
     />
   );

--- a/frontend/src/features/event/editor/editor.tsx
+++ b/frontend/src/features/event/editor/editor.tsx
@@ -160,6 +160,7 @@ function EventEditorContent({ type, initialData }: EventEditorProps) {
                 value={eventRange.timeRange.from}
                 onChange={setStartTime}
                 placeholder="Start Time"
+                dialogTitle="Select Start Time"
               />
             </FormSelectorField>
 
@@ -169,6 +170,7 @@ function EventEditorContent({ type, initialData }: EventEditorProps) {
                 value={eventRange.timeRange.to}
                 onChange={setEndTime}
                 placeholder="End Time"
+                dialogTitle="Select End Time"
               />
             </FormSelectorField>
           </div>


### PR DESCRIPTION
This PR changes the time selector drawers to have "Select Start Time" and "Select End Time" instead of just "Select Time".