### PR TITLE
Remove `text-md` instances

### DIFF
--- a/frontend/src/app/version-history/page-client.tsx
+++ b/frontend/src/app/version-history/page-client.tsx
@@ -112,7 +112,7 @@ function TimelineSegment({
             isCurrent ? "bg-accent text-white" : "bg-foreground",
           )}
         >
-          <h2 className="text-md px-2 font-bold">{version}</h2>
+          <h2 className="px-2 font-bold">{version}</h2>
         </div>
       ) : (
         <div

--- a/frontend/src/components/checkbox.tsx
+++ b/frontend/src/components/checkbox.tsx
@@ -40,7 +40,7 @@ export default function Checkbox(props: CheckboxProps) {
         htmlFor={"checkbox-" + id}
         className={cn(
           "cursor-pointer select-none",
-          textSize === "sm" ? "text-sm" : "text-md",
+          textSize === "sm" ? "text-sm" : "text-base",
           checked && "text-accent",
         )}
       >

--- a/frontend/src/features/account/settings/sidebar-nav.tsx
+++ b/frontend/src/features/account/settings/sidebar-nav.tsx
@@ -23,7 +23,7 @@ export default function SettingsNav() {
             key={tab.href}
             href={tab.href}
             className={cn(
-              "text-md focus-visible:ring-primary/50 relative flex items-center whitespace-nowrap rounded-full px-4 py-2.5 font-medium outline-none focus-visible:ring-2",
+              "focus-visible:ring-primary/50 relative flex items-center whitespace-nowrap rounded-full px-4 py-2.5 font-medium outline-none focus-visible:ring-2",
               isActive
                 ? "bg-foreground/10 text-foreground"
                 : "text-foreground/60 hover:bg-foreground/5 hover:text-foreground",

--- a/frontend/src/features/event/results/attendees/panel-header.tsx
+++ b/frontend/src/features/event/results/attendees/panel-header.tsx
@@ -70,7 +70,7 @@ export default function PanelHeader({
       )}
     >
       <div className="flex flex-col items-start">
-        <h2 className="text-md font-semibold">
+        <h2 className="font-semibold">
           {totalParticipants === 0
             ? "No Attendees Yet"
             : isRemoving


### PR DESCRIPTION
This PR removes all instances of `text-md`, since that's actually not a valid Tailwind class. Instead, you're supposed to use `text-base`, which I've replaced one instance with since it could inherit text size otherwise. The rest just had the text class removed.