### PR TITLE
Safari cookie duration hotfix

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,3 +4,8 @@ NEXT_PUBLIC_DEBUG=true
 # The API URL for both the client and the Next.js server to communicate with the backend
 # Note the lack of a trailing slash
 NEXT_PUBLIC_API_URL=https://example.com
+
+# The domain for cookies to be extended on. This is for the temporary fix implemented in
+# middleware.ts, and it MUST be the same as COOKIE_DOMAIN in the backend .env file. This
+# is not needed for development, since it's not used when NEXT_PUBLIC_DEBUG is true.
+COOKIE_DOMAIN=.example.com

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -51,21 +51,23 @@ export function middleware(request: NextRequest) {
     // sessions are not prematurely expired. The source of truth is handled by the backend
     // and database.
 
-    existingCookies.forEach((name) => {
-      const cookieValue = request.cookies.get(name)?.value;
-      if (cookieValue) {
-        response.cookies.set({
-          name: name,
-          value: cookieValue,
-          domain: process.env.COOKIE_DOMAIN,
-          path: "/",
-          httpOnly: true,
-          secure: true,
-          sameSite: "lax",
-          maxAge: 60 * 60 * 24 * 365, // 1 year
-        });
-      }
-    });
+    if (process.env.COOKIE_DOMAIN) {
+      existingCookies.forEach((name) => {
+        const cookieValue = request.cookies.get(name)?.value;
+        if (cookieValue) {
+          response.cookies.set({
+            name: name,
+            value: cookieValue,
+            domain: process.env.COOKIE_DOMAIN,
+            path: "/",
+            httpOnly: true,
+            secure: true,
+            sameSite: "lax",
+            maxAge: 60 * 60 * 24 * 365, // 1 year
+          });
+        }
+      });
+    }
 
     // We defensively try to DELETE the Host-Only (legacy) cookies on every request.
     // By setting Max-Age=0 and omitting the Domain attribute, we target the Host-Only version.

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -34,30 +34,27 @@ export function middleware(request: NextRequest) {
 
   if (process.env.NEXT_PUBLIC_DEBUG !== "true") {
     const cookieNames = ["account_sess_token", "guest_sess_token"];
-    const hasLegacyCookies = cookieNames.some((name) =>
+    const existingCookies = cookieNames.filter((name) =>
       request.cookies.has(name),
     );
 
-    // If the user has auth cookies...
-    if (hasLegacyCookies) {
-      // We defensively try to DELETE the Host-Only (legacy) cookies on every request.
-      // By setting Max-Age=0 and omitting the Domain attribute, we target the Host-Only version.
-      // The valid Domain cookie (.example.com) will remain untouched because the browser
-      // sees them as different scopes.
+    // We defensively try to DELETE the Host-Only (legacy) cookies on every request.
+    // By setting Max-Age=0 and omitting the Domain attribute, we target the Host-Only version.
+    // The valid Domain cookie (.example.com) will remain untouched because the browser
+    // sees them as different scopes.
 
-      // This logic can only be removed AFTER February 15, 2027 (one year from now) just
-      // to be safe, since long session cookies have a 1 year lifetime
+    // This logic can only be removed AFTER February 15, 2027 (one year from now) just
+    // to be safe, since long session cookies have a 1 year lifetime
 
-      cookieNames.forEach((name) => {
-        // Because we initialized `response` with NextResponse.next() above,
-        // we can safely append headers to it here. If response was reassigned
-        // to a redirect, appending headers still works.
-        response.headers.append(
-          "Set-Cookie",
-          `${name}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`,
-        );
-      });
-    }
+    existingCookies.forEach((name) => {
+      // Because we initialized `response` with NextResponse.next() above,
+      // we can safely append headers to it here. If response was reassigned
+      // to a redirect, appending headers still works.
+      response.headers.append(
+        "Set-Cookie",
+        `${name}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`,
+      );
+    });
   }
 
   return response;

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -38,6 +38,35 @@ export function middleware(request: NextRequest) {
       request.cookies.has(name),
     );
 
+    // Safari's ITP (Intelligent Tracking Prevention) limits the lifetime of cookies set
+    // by direct requests to our API to 7 days. To combat this, we extend cookie lifetimes
+    // with Next.js to a full year on every request. In oversimplified terms, the frontend
+    // is on the main domain which is not subject to the same restrictions.
+
+    // This solution is a temporary fix until we redo our client-side API requests to use
+    // Server Actions, which will route everything through the frontend and bypass the
+    // restriction.
+
+    // This won't allow authentication for expired sessions, it only ensures that valid
+    // sessions are not prematurely expired. The source of truth is handled by the backend
+    // and database.
+
+    existingCookies.forEach((name) => {
+      const cookieValue = request.cookies.get(name)?.value;
+      if (cookieValue) {
+        response.cookies.set({
+          name: name,
+          value: cookieValue,
+          domain: process.env.COOKIE_DOMAIN,
+          path: "/",
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          maxAge: 60 * 60 * 24 * 365, // 1 year
+        });
+      }
+    });
+
     // We defensively try to DELETE the Host-Only (legacy) cookies on every request.
     // By setting Max-Age=0 and omitting the Domain attribute, we target the Host-Only version.
     // The valid Domain cookie (.example.com) will remain untouched because the browser


### PR DESCRIPTION
I discovered an issue where, on Safari, our session cookies are limited to only having a lifetime of 7 days, despite the intended duration being 1 year for guests and accounts with "remember me" checked on login.

This happens because of Safari's ITP (Intelligent Tracking Prevention), which, to explain it simply, doesn't like that our frontend and backend are on very different servers. Thus, it limits the cookie lifetime to prevent tracking.

The solution I implemented is a bit of a band-aid fix, similar to the host-only cookie deletion. It adds logic to the Next.js middleware that extends the lifetime of all session cookies on every request to 1 year. This works because our domain maps directly to the frontend server, so cookies from there will be treated just fine. In addition, the backend validates every session cookie it accepts, so this won't cause any problems with expired sessions.
- I tried to find a solution that just forwards cookies from the backend when the server makes requests to it during rendering, but that's not possible. Next.js sends a response to the client before starting server component rendering and HTML streaming.

The long-term solution for this would be either:
- Converting all direct client-to-backend requests into server actions
- Going back to using Next.js rewrites to proxy API requests
- Reworking our production server infrastructure to something else