### PR TITLE
Results page banner priority update

### DIFF
--- a/frontend/src/app/(event)/[event-code]/page-client.tsx
+++ b/frontend/src/app/(event)/[event-code]/page-client.tsx
@@ -84,6 +84,7 @@ function EventResults({ eventData }: { eventData: EventInformation }) {
     timeslots,
     eventRange.type === "weekday",
     currentUser !== null,
+    isCreator,
   );
 
   /* BUTTONS */

--- a/frontend/src/features/event/results/components/banners.tsx
+++ b/frontend/src/features/event/results/components/banners.tsx
@@ -12,7 +12,14 @@ export function getResultBanners(
   timeslots: Date[],
   isWeekEvent: boolean,
   participated: boolean,
+  isCreator: boolean,
 ) {
+  const shareLinkBanner = (
+    <Banner type="info" subtitle="Waiting for responses..." showPing>
+      <p>{MESSAGES.INFO_COPY_SHARE_LINK}</p>
+    </Banner>
+  );
+
   if (
     !isWeekEvent &&
     timeslots.length > 0 &&
@@ -21,17 +28,8 @@ export function getResultBanners(
     return (
       <Banner type="info" subtitle={MESSAGES.INFO_EVENT_PASSED} showPing />
     );
-  } else if (participants.length === 0) {
-    return (
-      <Banner
-        type="info"
-        subtitle="No one has submitted availability!"
-        showPing
-      >
-        <p className="md:hidden">{MESSAGES.INFO_ADD_AVAILABILITY_MOBILE}</p>
-        <p className="hidden md:block">{MESSAGES.INFO_ADD_AVAILABILITY}</p>
-      </Banner>
-    );
+  } else if (isCreator && participants.length === 0) {
+    return shareLinkBanner;
   } else if (!hasMutualAvailability(availabilities, participants)) {
     if (getHighestMatchCount(availabilities) <= 1) {
       return (
@@ -46,11 +44,7 @@ export function getResultBanners(
       </Banner>
     );
   } else if (participated && participants.length === 1) {
-    return (
-      <Banner type="info" subtitle="Waiting for others..." showPing>
-        <p>{MESSAGES.INFO_COPY_SHARE_LINK}</p>
-      </Banner>
-    );
+    return shareLinkBanner;
   } else if (!participated) {
     return (
       <Banner type="info" subtitle="Don't be a stranger!" showPing>


### PR DESCRIPTION
To align better with our "4-step process", the results page banner priority was updated.

When there are no participants:
- If you are the event creator, you are now prompted to share the link with others first instead of adding your availability.
- If you are NOT the event creator, it just tells you to add your availability (this is the current behavior).

The event creator is shown the banner to add availability after someone else has submitted their availability.