### PR TITLE
Scrollbar adjustment

### DIFF
--- a/frontend/src/features/event/grid/schedule-header.tsx
+++ b/frontend/src/features/event/grid/schedule-header.tsx
@@ -55,7 +55,7 @@ export default function ScheduleHeader({
     <div
       className={cn(
         preview ? "md:bg-panel top-0" : cn(topMarginClass, "bg-background"),
-        scrollbarPresent && "pr-4",
+        scrollbarPresent && "pr-3",
         "sticky z-10 col-span-2 grid h-[50px] w-full items-center justify-center",
       )}
       style={{

--- a/frontend/src/features/event/grid/timeblocks/base.tsx
+++ b/frontend/src/features/event/grid/timeblocks/base.tsx
@@ -15,7 +15,7 @@ export default function BaseTimeBlock({
 }: TimeBlockProps) {
   return (
     <div
-      className="relative isolate grid"
+      className="relative isolate grid overflow-x-clip"
       onMouseLeave={onMouseLeave}
       style={{
         gridTemplateColumns: `${TIME_LABEL_WIDTH}px 1fr ${hasNext ? SIDE_WIDTH : 10}px`,

--- a/frontend/src/styles/radix.css
+++ b/frontend/src/styles/radix.css
@@ -98,3 +98,17 @@
     transform: scale(0.95) translateY(10px);
   }
 }
+
+/* Disabling scrollbar margin management */
+html body[data-scroll-locked] {
+  /*
+    When opening a modal, Radix will add padding/margin to the body to counteract a
+    dynamic scrollbar that disappears.
+
+    Our custom scrollbar was made persistent, so we want to override this behavior,
+    otherwise the content will shift to the left anyway when opening a modal.
+  */
+  --removed-body-scroll-bar-size: 0px !important;
+  margin-right: 0px !important;
+  padding-right: 0px !important;
+}

--- a/frontend/src/styles/radix.css
+++ b/frontend/src/styles/radix.css
@@ -109,6 +109,7 @@ html body[data-scroll-locked] {
     otherwise the content will shift to the left anyway when opening a modal.
   */
   --removed-body-scroll-bar-size: 0px !important;
+
   margin-right: 0px !important;
   padding-right: 0px !important;
 }

--- a/frontend/src/styles/scrollbar.css
+++ b/frontend/src/styles/scrollbar.css
@@ -17,7 +17,7 @@
 }
 
 ::-webkit-scrollbar {
-  width: 16px;
+  width: 12px;
   background-color: transparent;
 }
 
@@ -25,7 +25,7 @@
   background-color: var(--sb-track-color);
 
   /* floating track */
-  border: 4px solid transparent;
+  border: 3px solid transparent;
   border-radius: 100vh;
   background-clip: padding-box;
 
@@ -37,7 +37,7 @@
   background-color: var(--sb-thumb-color);
 
   /* floating track */
-  border: 4px solid transparent;
+  border: 3px solid transparent;
   border-radius: 100vh;
   background-clip: padding-box;
 }

--- a/frontend/src/styles/scrollbar.css
+++ b/frontend/src/styles/scrollbar.css
@@ -12,6 +12,10 @@
   }
 }
 
+html {
+  overflow-y: scroll;
+}
+
 ::-webkit-scrollbar-button {
   display: none;
 }

--- a/frontend/src/styles/scrollbar.css
+++ b/frontend/src/styles/scrollbar.css
@@ -44,4 +44,5 @@
 
 ::-webkit-scrollbar-thumb:hover {
   background-color: var(--foreground);
+  border: 2px solid transparent;
 }


### PR DESCRIPTION
This PR was originally intended to change the scrollbar to act as an overlay, instead of taking up physical space in the layout. I ended up with a different solution though.

### Persistent Scrollbar
The problem I was trying to solve was the layout shfiting when the scrollbar appeared or disappeared. This happened in three cases:
- When going between two pages, where one was scrollable and the other not
- When a page's loading skeleton was not scrollable, but the actual content was
- When opening a drawer on the mobile layout

I initially tried using the Radix UI Scroll Area, but this came with a lot of compromises from not using native scroll functionality. In the end, my solution was just to have a persistent page scrollbar, where it still takes up (minimal) space when the page isn't scrollable. This is a common solution used by websites like GitHub.

What I discovered was that no matter how you style the scrollbar, it will always have an "overlay" functionality that doesn't disrupt the layout on iOS and Android. The cases of going between pages was worth addressing though, so a persistent scrollbar deals with this nicely while staying out of the way when unused.

I shrunk the scrollbar just a bit to further keep it out of the way, but now it grows slightly on hover.

### Fixed Grid Horizontal Scroll
If you dragged on the results grid and triggered text highlighting, it would scroll the grid slightly to the right if you drag past the right edge. I added `overflow-x-clip` to `BaseTimeBlock` to fix this, since it was the "next page" indicator taking up space even when hidden that caused this.